### PR TITLE
The constraints check is no longer instantiated

### DIFF
--- a/src/include/mallocMC/mallocMC_constraints.hpp
+++ b/src/include/mallocMC/mallocMC_constraints.hpp
@@ -37,19 +37,19 @@ namespace mallocMC{
   /** The default PolicyCheckers (do always succeed)
    */
   template<typename Policy1>
-  struct PolicyCheck1{};
+  class PolicyCheck1{};
 
   template<typename Policy1, typename Policy2>
-  struct PolicyCheck2{};
+  class PolicyCheck2{};
 
   template<typename Policy1, typename Policy2, typename Policy3>
-  struct PolicyCheck3{};
+  class PolicyCheck3{};
 
   template<typename Policy1, typename Policy2, typename Policy3, typename Policy4>
-  struct PolicyCheck4{};
+  class PolicyCheck4{};
 
   template<typename Policy1, typename Policy2, typename Policy3, typename Policy4, typename Policy5>
-  struct PolicyCheck5{};
+  class PolicyCheck5{};
 
 
   /** Enforces constraints on policies or combinations of polices
@@ -63,7 +63,8 @@ namespace mallocMC{
      typename T_GetHeapPolicy,
      typename T_AlignmentPolicy
        >
-  struct PolicyConstraints:PolicyCheck2<T_CreationPolicy, T_DistributionPolicy>{
+
+  class PolicyConstraints:PolicyCheck2<T_CreationPolicy, T_DistributionPolicy>{
 
   };
 
@@ -75,7 +76,7 @@ namespace mallocMC{
    * the same value for their "pagesize"-parameter.
    */
   template<typename x, typename y, typename z >
-  struct PolicyCheck2<
+  class PolicyCheck2<
     typename CreationPolicies::Scatter<x,y>,
     typename DistributionPolicies::XMallocSIMD<z> 
   >{

--- a/src/include/mallocMC/mallocMC_constraints.hpp
+++ b/src/include/mallocMC/mallocMC_constraints.hpp
@@ -63,8 +63,8 @@ namespace mallocMC{
      typename T_GetHeapPolicy,
      typename T_AlignmentPolicy
        >
-  class PolicyConstraints{
-      PolicyCheck2<T_CreationPolicy, T_DistributionPolicy> c;
+  struct PolicyConstraints:PolicyCheck2<T_CreationPolicy, T_DistributionPolicy>{
+
   };
 
 

--- a/src/include/mallocMC/mallocMC_hostclass.hpp
+++ b/src/include/mallocMC/mallocMC_hostclass.hpp
@@ -83,7 +83,8 @@ namespace mallocMC{
     public T_CreationPolicy, 
     public T_OOMPolicy, 
     public T_ReservePoolPolicy,
-    public T_AlignmentPolicy
+    public T_AlignmentPolicy,
+    public PolicyConstraints<T_CreationPolicy,T_DistributionPolicy,T_OOMPolicy,T_ReservePoolPolicy,T_AlignmentPolicy>
   {
     public:
       typedef T_CreationPolicy CreationPolicy;
@@ -95,10 +96,6 @@ namespace mallocMC{
     private:
       typedef boost::uint32_t uint32;
       void* pool;
-
-      //Instantiating the constraints checker will execute the check
-      PolicyConstraints<CreationPolicy,DistributionPolicy,
-        OOMPolicy,ReservePoolPolicy,AlignmentPolicy> c;
 
     public:
 


### PR DESCRIPTION
This reduces the size of the allocator object from 64byte to 56byte, since the policy checker object is not held as a class member.