### PR TITLE
Removed overwriting of CUDA malloc/new

### DIFF
--- a/examples/mallocMC_example01.cu
+++ b/examples/mallocMC_example01.cu
@@ -105,7 +105,7 @@ void run()
   size_t block = 32;
   size_t grid = 32;
   int length = 100;
-  assert(length<= block*grid); //necessary for used algorithm
+  assert((unsigned)length<= block*grid); //necessary for used algorithm
 
   //init the heap
   std::cerr << "initHeap...";

--- a/tests/verify_heap.cu
+++ b/tests/verify_heap.cu
@@ -50,9 +50,8 @@
 #include "src/include/mallocMC/mallocMC_utils.hpp"
 #include "verify_heap_config.hpp"
 
-//use ScatterAllocator to replace malloc/free
+//use ScatterAllocator
 MALLOCMC_SET_ALLOCATOR_TYPE(ScatterAllocator)
-MALLOCMC_OVERWRITE_MALLOC()
 
 // global variable for verbosity, might change due to user input '--verbose'
 bool verbose = false;


### PR DESCRIPTION
 - only valid option is now to use `mallocMC::malloc()` and
   `mallocMC::free()`
 - examples were modified to use the new syntax
 - close #72 