### PR TITLE
Moved the onpagemasks to end of page

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -249,12 +249,6 @@ namespace ScatterKernelDetail{
        * @return pointer to the first address inside the page that holds metadata bitfields.
        */
       __device__ inline uint32* onPageMasksPosition(uint32 page, uint32 nMasks){
-        //uint32* x = (uint32*)(_page[page].data + pagesize - (int)sizeof(uint32)*nMasks);
-        //uint32* s = (uint32*)_page[page].data;
-        //uint32* e = (uint32*)(_page[page].data+pagesize);
-        //  printf("start %p end %p. diff=%lld  masks: %p diff_to_begin: %lld diff to end: %lld (pagesize is %d, there are %d masks)\n",
-        //          s, e, e-s, x, x-s, e-x, pagesize,nMasks);
-        //return x;
         return (uint32*)(_page[page].data + pagesize - (int)sizeof(uint32)*nMasks);
       }
 

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -132,6 +132,8 @@ namespace ScatterKernelDetail{
       //static const uint32 minChunkSize0 = pagesize/(32*32);
       static const uint32 minChunkSize1 = 0x10;
       static const uint32 HierarchyThreshold =  (pagesize - 2*sizeof(uint32))/33;
+      static const uint32 tmp_maxOPM = minChunkSize1 > HierarchyThreshold ? 0 : pagesize/(32*minChunkSize1 + 1);
+      static const uint32 maxOnPageMasks = 32 > tmp_maxOPM ? tmp_maxOPM : 32;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGK
 #define MALLOCMC_CP_SCATTER_HASHINGK    static_cast<uint32>(HashingProperties::hashingK::value)
@@ -190,8 +192,7 @@ namespace ScatterKernelDetail{
         __device__ void init()
         {
           //clear the entire data which can hold bitfields
-          uint32 first_possible_metadata = 32*HierarchyThreshold;
-          uint32* write = (uint32*)(data+(pagesize-first_possible_metadata));
+          uint32* write = (uint32*)(data + pagesize - (int)(sizeof(uint32)*maxOnPageMasks));
           while(write < (uint32*)(data + pagesize))
             *write++ = 0;
         }
@@ -239,6 +240,23 @@ namespace ScatterKernelDetail{
         return (spot + step) % spots;
       }
 
+
+      /**
+       * onPageMasksPosition returns a pointer to the beginning of the onpagemasks inside a page.
+       * @param page the page that holds the masks
+       * @param the number of hierarchical page tables (bitfields) that are used inside this mask.
+       * @return pointer to the first address inside the page that holds metadata bitfields.
+       */
+      __device__ inline uint32* onPageMasksPosition(uint32 page, uint32 nMasks){
+        //uint32* x = (uint32*)(_page[page].data + pagesize - (int)sizeof(uint32)*nMasks);
+        //uint32* s = (uint32*)_page[page].data;
+        //uint32* e = (uint32*)(_page[page].data+pagesize);
+        //  printf("start %p end %p. diff=%lld  masks: %p diff_to_begin: %lld diff to end: %lld (pagesize is %d, there are %d masks)\n",
+        //          s, e, e-s, x, x-s, e-x, pagesize,nMasks);
+        //return x;
+        return (uint32*)(_page[page].data + pagesize - (int)sizeof(uint32)*nMasks);
+      }
+
       /**
        * usespot marks finds one free spot in the bitfield, marks it and returns its offset
        * @param bitfield pointer to the bitfield to use
@@ -279,7 +297,7 @@ namespace ScatterKernelDetail{
         if((mask & (1 << spot)) != 0)
           spot = nextspot(mask, spot, segments);
         uint32 tries = segments - __popc(mask);
-        uint32* onpagemasks = (uint32*)(_page[page].data + chunksize*(fullsegments*32 + additional_chunks));
+        uint32* onpagemasks = onPageMasksPosition(page,segments);
         for(uint32 i = 0; i < tries; ++i)
         {
           int hspot = usespot(onpagemasks + spot, spot < fullsegments ? 32 : additional_chunks);
@@ -442,7 +460,8 @@ namespace ScatterKernelDetail{
           uint32 segment = inpage_offset / (chunksize*32);
           uint32 withinsegment = (inpage_offset - segment*(chunksize*32))/chunksize;
           //mark it as free
-          uint32* onpagemasks = (uint32*)(_page[page].data + chunksize*(fullsegments*32 + additional_chunks));
+          uint32 nMasks = fullsegments + (additional_chunks > 0 ? 1 : 0);
+          uint32* onpagemasks = onPageMasksPosition(page,nMasks);
           uint32 old = atomicAnd(onpagemasks + segment, ~(1 << withinsegment));
 
           // always do this, since it might fail due to a race-condition with addChunkHierarchy

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -132,7 +132,8 @@ namespace ScatterKernelDetail{
       //static const uint32 minChunkSize0 = pagesize/(32*32);
       static const uint32 minChunkSize1 = 0x10;
       static const uint32 HierarchyThreshold =  (pagesize - 2*sizeof(uint32))/33;
-      static const uint32 tmp_maxOPM = minChunkSize1 > HierarchyThreshold ? 0 : pagesize/(32*minChunkSize1 + 1);
+      static const uint32 minSegmentSize = 32*minChunkSize1 + sizeof(uint32);
+      static const uint32 tmp_maxOPM = minChunkSize1 > HierarchyThreshold ? 0 : (pagesize + (minSegmentSize-1)) / minSegmentSize;
       static const uint32 maxOnPageMasks = 32 > tmp_maxOPM ? tmp_maxOPM : 32;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGK


### PR DESCRIPTION
## TL;DR
`onpagemasks` is now always at the end of a page, so we save time when a page is freed.

## Full Text
When a page is reset, the area holding the `onpagetable` bitfields needs to be zero-filled. Doing this during the reset rather than during the allocation is thought to improve allocation times. However, the data layout of the page (see Fig. 1) leaves a lot of possible positions for the `onpagetables`, depending on the chunksize.
### Figure 1: Currently, `onpagetables` are located directly behind the data:
![moved_onpagetables_1](https://cloud.githubusercontent.com/assets/903310/5861162/10059b0a-a267-11e4-9a7c-78d9afb780c0.png)

Fig. 2 displays a worst-case scenario with small chunk sizes, where most of the page is empty and the `onpagetables` located near the beginning of the page.
### Figure 2: `onpagetables` is located near the beginning of the page:
![moved_onpagetables_2](https://cloud.githubusercontent.com/assets/903310/5861235/a294588a-a267-11e4-9168-eef6f5f22aa9.png)

Since the zero-filling process takes place at the time the page is freed, it is impossible to know where the next allocation will place the `onpagetables`. Therefore, all possible positions for `onpagetable` need to be cleared (see Fig. 3). Benchmarks show that this is a major bottleneck when using large pages.
### Figure 3: considering the worst case, most of the page must be cleared:
![moved_onpagetables_3](https://cloud.githubusercontent.com/assets/903310/5861315/5fb6d1a4-a268-11e4-9cf8-010963b6f60c.png)

**This PullRequest** moves the `onpagetable` entries to the end of the page, without changing any other properties of the data (ordering of `onpagetable` entries stays the same). Fig. 4 depicts the page layout for the previous scenario with very small chunk sizes.
### Figure 4: even for small chunk sizes, `onpagetable` is located at the end:
![moved_onpagetables_4](https://cloud.githubusercontent.com/assets/903310/5861359/edea38c6-a268-11e4-8f31-cfb0fa65fa3f.png)

Since the location of `onpagetable` is now fixed, it is easy to determine how much of the page needs to be cleared. At most, 32 integers at the end of the page can be occupied by `onpagetables`. This might be even less for very small pages. The expected benefit is a much faster behaviour of `free()` in certain situations.

### Figure 5: only a small area needs to be cleared, since the position is fixed:
![moved_onpagetables_5](https://cloud.githubusercontent.com/assets/903310/5861436/8780f664-a269-11e4-8fe9-f9cfc86890fc.png)

## Additional Stuff
- This PR should be accepted AFTER #79 is merged to avoid possible heap corruptions (not sure, though).
- The calculation of the `onpagemask` offset occurs at 2 positions and was moved to a function.