### PR TITLE
added host function to return heap pointer

### DIFF
--- a/src/include/mallocMC/mallocMC_hostclass.hpp
+++ b/src/include/mallocMC/mallocMC_hostclass.hpp
@@ -57,6 +57,11 @@ namespace mallocMC{
     static const bool providesAvailableSlots = T::CreationPolicy::providesAvailableSlots::value;
   };
 
+  class HeapInfo{
+    public:
+      void* p;
+      size_t size;
+  };
 
   /**
    * @brief "HostClass" that combines all policies to a useful allocator
@@ -96,6 +101,7 @@ namespace mallocMC{
     private:
       typedef boost::uint32_t uint32;
       void* pool;
+      HeapInfo heapInfos;
 
     public:
 
@@ -129,6 +135,8 @@ namespace mallocMC{
         pool = ReservePoolPolicy::setMemPool(size);
         boost::tie(pool,size) = AlignmentPolicy::alignPool(pool,size);
         void* h = CreationPolicy::initHeap(*this,pool,size);
+        heapInfos.p=pool;
+        heapInfos.size=size;
 
         /*
         * This is a workaround for a bug with getAvailSlotsPoly:
@@ -168,6 +176,13 @@ namespace mallocMC{
       MAMC_HOST MAMC_ACCELERATOR
       unsigned getAvailableSlots(size_t slotSize){
         return getAvailSlotsPoly(slotSize, boost::mpl::bool_<CreationPolicy::providesAvailableSlots::value>());
+      }
+
+      MAMC_HOST
+      std::vector<mallocMC::HeapInfo> getHeapLocations(){
+        std::vector<mallocMC::HeapInfo> v;
+        v.push_back(heapInfos);
+        return v;
       }
 
     private:

--- a/src/include/mallocMC/mallocMC_overwrites.hpp
+++ b/src/include/mallocMC/mallocMC_overwrites.hpp
@@ -103,6 +103,20 @@ void  free(void* p) __THROW                                                    \
 } /* end namespace mallocMC */
 
 
+/** Create the function getHeapLocations inside a namespace
+ *
+ * This returns a vector of type mallocMC::HeapInfo. The HeapInfo should at least
+ * contain the pointer to the heap (on device) and its size.
+ */
+#define MALLOCMC_HEAPLOC()                                                     \
+namespace mallocMC{                                                            \
+MAMC_HOST                                                                      \
+std::vector<mallocMC::HeapInfo> getHeapLocations()                             \
+{                                                                              \
+  return mallocMC::mallocMCGlobalObject.getHeapLocations();                    \
+}                                                                              \
+} /* end namespace mallocMC */
+
 
 /* if the defines do not exist (wrong CUDA version etc),
  * create at least empty defines
@@ -121,4 +135,5 @@ void  free(void* p) __THROW                                                    \
 #define MALLOCMC_SET_ALLOCATOR_TYPE(MALLOCMC_USER_DEFINED_TYPE)                  \
 MALLOCMC_GLOBAL_FUNCTIONS(MALLOCMC_USER_DEFINED_TYPE)                            \
 MALLOCMC_MALLOC()                                                               \
+MALLOCMC_HEAPLOC()                                                              \
 MALLOCMC_AVAILABLESLOTS()


### PR DESCRIPTION
 This is a review for discussion (and potentially merging after a while)

In the current version, this adds a HeapInfo object to the allocator, which is used to track the pointer and the exact size of the heap.  

For future improvements, there should be a datastructure that holds multiple HeapInfo objects, since it is not guaranteed that there is only 1 heap. The idea is, that each HeapInfo object could hold information about how to access the objects in the memory-region (which allocator to use) and how the different regions are related (multiple HeapInfo objects must be in a certain order and belong to the same allocator).

See #28

Text form the commit message:
- use: std::vector<HeapInfo> mallocMC::getHeapLocations()
- uses a vector, since future allocators might have more than 1 heap
   (and those are not necessarily located one after another)
- currently, HeapInfo contains size and a pointer p
- the pointer is the device address (as it would be returned my
   cudaMalloc for example)
- the CUDA toolkit allocator will currently return NULL. Ideas very
   welcome. Problem: we have no pointer address for its internal heap
   (might be multiple heaps, who knows). Also, we don't know how objects
   are organized on the heap, so copying to host might be of limited
   value anyway.