### PR TITLE
fix non-matching class/struct declaration

### DIFF
--- a/src/include/mallocMC/oOMPolicies/BadAllocException.hpp
+++ b/src/include/mallocMC/oOMPolicies/BadAllocException.hpp
@@ -39,7 +39,7 @@ namespace OOMPolicies{
    * accelerators. Using this policy on other types of accelerators that do not
    * support exceptions results in undefined behaviour.
    */
-  class BadAllocException;
-    
+  struct BadAllocException;
+
 } //namespace OOMPolicies
 } //namespace mallocMC


### PR DESCRIPTION
The `BadAllocException` class is defined using `struct` but is forward declared using `class`.
Because `BadAllocException` does not have any private members I propose to change the forward declaration to `struct`.