### PR TITLE
Define __THROW for systems without Glibc

### DIFF
--- a/src/include/mallocMC/mallocMC_overwrites.hpp
+++ b/src/include/mallocMC/mallocMC_overwrites.hpp
@@ -83,6 +83,12 @@ bool providesAvailableSlots(){                                                 \
 } /* end namespace mallocMC */
 
 
+/** __THROW is defined in Glibc so it is not available on all platforms.
+ */
+#ifndef __THROW
+  #define __THROW
+#endif 
+
 /** Create the functions malloc() and free() inside a namespace
  *
  * This allows for a peaceful coexistence between different functions called


### PR DESCRIPTION
__THROW is defined in Glibc so it is not available on all platforms.
The safest way to fix this is to define it empty for platforms where it is not available.
Maybe it is also safe to remove it completely.