### PR TITLE
Close #92: Update CMake Version to 2.8.12.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ script:
   - make examples
 
 before_script:
+  - sudo add-apt-repository --yes ppa:smspillaz/cmake-2.8.12
   - sudo apt-get update -qq
+  - sudo apt-get install -q -y cmake-data cmake
   - sudo apt-get install -qq build-essential
   - sudo apt-get install -qq gcc-4.4 g++-4.4
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.4 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(mallocMC)
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 2.8.12.2)
 
 # helper for libs and packages
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ Install
    - *Debian/Ubuntu:* `sudo apt-get install libboost-dev libboost-program-options-dev`
    - *Arch Linux:* `sudo pacman -S boost`
    - or download from [http://www.boost.org/](http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz/download)
- - `CMake` >= 2.8.5
+ - `CMake` >= 2.8.12.2
   - *Debian/Ubuntu:* `sudo apt-get install cmake file cmake-curses-gui`
   - *Arch Linux:* `sudo pacman -S cmake`
  - `git` >= 1.7.9.5
@@ -65,8 +65,8 @@ cmake -DCMAKE_MODULE_PATH=. --help-module FindmallocMC | less
 
 and use the following lines in your `CMakeLists.txt`:
 ```cmake
-# this example will require at least CMake 2.8.5
-cmake_minimum_required(VERSION 2.8.5)
+# this example will require at least CMake 2.8.12.2
+cmake_minimum_required(VERSION 2.8.12.2)
 
 # add path to FindmallocMC.cmake, e.g., in the directory in cmake/
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)


### PR DESCRIPTION
Require CMake 2.8.12.2+ for the whole project to ensure the full build chain until a project that is using the FindmallocMC.cmake module will pass. Closes #92.

Dependency increased in
  https://github.com/ComputationalRadiationPhysics/cmake-modules/pull/8