### PR TITLE
Wshadow Compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 
 script:
   - mkdir build_tmp && cd build_tmp
-  - cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR $TRAVIS_BUILD_DIR
+  - CXXFLAGS="-Werror" cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR $TRAVIS_BUILD_DIR
   - make
   - make install
   - make examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,18 +46,20 @@ endif(Boost_VERSION EQUAL 105500)
 # GNU
 if(CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
   # new warning in gcc 4.8 (flag ignored in previous version)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
-  # ICC
+# ICC
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_VARIADIC_TEMPLATES")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_VARIADIC_TEMPLATES")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_FENV_H")
-  # PGI
+# PGI
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minform=inform")
 endif()

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -49,20 +49,20 @@ namespace CUDA
   class error : public std::runtime_error
   {
   private:
-    static std::string genErrorString(cudaError error, const char* file, int line)
+    static std::string genErrorString(cudaError errorValue, const char* file, int line)
     {
       std::ostringstream msg;
-      msg << file << '(' << line << "): error: " << cudaGetErrorString(error);
+      msg << file << '(' << line << "): error: " << cudaGetErrorString(errorValue);
       return msg.str();
     }
   public:
-    error(cudaError error, const char* file, int line)
-      : runtime_error(genErrorString(error, file, line))
+    error(cudaError errorValue, const char* file, int line)
+      : runtime_error(genErrorString(errorValue, file, line))
     {
     }
 
-    error(cudaError error)
-      : runtime_error(cudaGetErrorString(error))
+    error(cudaError errorValue)
+      : runtime_error(cudaGetErrorString(errorValue))
     {
     }
 
@@ -72,11 +72,11 @@ namespace CUDA
     }
   };
 
-  inline void checkError(cudaError error, const char* file, int line)
+  inline void checkError(cudaError errorValue, const char* file, int line)
   {
 #ifdef _DEBUG
-    if (error != cudaSuccess)
-      throw CUDA::error(error, file, line);
+    if (errorValue != cudaSuccess)
+      throw CUDA::error(errorValue, file, line);
 #endif
   }
 
@@ -88,9 +88,9 @@ namespace CUDA
   inline void checkError()
   {
 #ifdef _DEBUG
-    cudaError error = cudaGetLastError();
-    if (error != cudaSuccess)
-      throw CUDA::error(error);
+    cudaError errorValue = cudaGetLastError();
+    if (errorValue != cudaSuccess)
+      throw CUDA::error(errorValue);
 #endif
   }
 


### PR DESCRIPTION
Due to the effort to confirm with `-Wshadow` in https://github.com/ComputationalRadiationPhysics/picongpu/issues/1042 , mallocMC should also fulfill this requirement.

This pull adds the flag to GCC & ICC and adds `-Werror` for compliance enforcement during the travis tests.

GCC:
 - Wshadow
 - Werror (used in compile suite)

ICC:
 - Wshadow