### PR TITLE
Added TODO to boost_static_assert cast warning

### DIFF
--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -74,6 +74,8 @@ namespace Shrink2NS{
 #endif
     static const uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
 
+    // \TODO: The static_cast can be removed once the minimal dependencies of
+    //        this project is are at least CUDA 7.0 and gcc 4.8.2
     BOOST_STATIC_ASSERT(static_cast<uint32>(dataAlignment) > 0);
     //dataAlignment must also be a power of 2!
     BOOST_STATIC_ASSERT(dataAlignment && !(dataAlignment & (dataAlignment-1)) ); 

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -77,6 +77,9 @@ namespace DistributionPolicies{
 
       //all the properties must be unsigned integers > 0
       BOOST_STATIC_ASSERT(!std::numeric_limits<typename Properties::pagesize::type>::is_signed);
+
+      // \TODO: The static_cast can be removed once the minimal dependencies of
+      //        this project is are at least CUDA 7.0 and gcc 4.8.2
       BOOST_STATIC_ASSERT(static_cast<uint32>(pagesize) > 0);
 
     public:


### PR DESCRIPTION
 - Since the warning (and the cast necessary to suppress it) are solved
   in newer versions of nvcc/gcc, one bright day in the future might
   permit us to remove that dreadful cast again.
 - see #65 