### PR TITLE
Fix crash in getAvailableSlots

### DIFF
--- a/src/include/mallocMC/mallocMC_hostclass.hpp
+++ b/src/include/mallocMC/mallocMC_hostclass.hpp
@@ -52,10 +52,9 @@ namespace mallocMC{
    * bool providesAvailableSlots: declares if the allocator implements a useful
    * version of getAvailableSlots().
    */
-  template <class T>
-  class  Traits : public T{
-    public:
-    static const bool providesAvailableSlots = T::CreationPolicy::providesAvailableSlots::value;
+  template <class T_Allocator>
+  struct  Traits{
+    static const bool providesAvailableSlots = T_Allocator::CreationPolicy::providesAvailableSlots::value;
   };
 
   class HeapInfo{
@@ -71,30 +70,37 @@ namespace mallocMC{
      *
      * Returns 0 else.
      *
-     * @tparam T_CreationPolicy The desired type of a CreationPolicy
-     * @tparam T_ProvidesAvailableSlotsHost If the CreationPolicy provides getAvailableSlotsHost
+     * @tparam T_Allocator The type of the Allocator to be used
+     * @tparam T_isHost True for the host call, false for the accelerator call
+     * @tparam T_providesAvailableSlots If the CreationPolicy provides getAvailableSlots[Host|Accelerator] (auto filled, do not set)
      */
-    template<typename T_ProvidesAvailableSlotsHost>
+    template<class T_Allocator, bool T_isHost, bool T_providesAvailableSlots = Traits<T_Allocator>::providesAvailableSlots >
     struct GetAvailableSlotsIfAvail
     {
-      template<typename T_Allocator>
       MAMC_HOST MAMC_ACCELERATOR
-      static unsigned getAvailableSlots(size_t slotSize, T_Allocator &){
+      static unsigned
+      getAvailableSlots(size_t slotSize, T_Allocator &){
         return 0;
       }
     };
-    template<>
-    struct GetAvailableSlotsIfAvail<
-      boost::mpl::bool_<true> >
+
+    template<class T_Allocator>
+    struct GetAvailableSlotsIfAvail<T_Allocator, true, true>
     {
-      template<typename T_Allocator>
-      MAMC_HOST MAMC_ACCELERATOR
-      static unsigned getAvailableSlots(size_t slotSize, T_Allocator & alloc){
-#ifdef __CUDA_ARCH__
-        return alloc.getAvailableSlotsAccelerator(slotSize);
-#else
-        return alloc.getAvailableSlotsHost(slotSize, alloc);
-#endif
+      MAMC_HOST
+      static unsigned
+      getAvailableSlots(size_t slotSize, T_Allocator& alloc){
+          return alloc.getAvailableSlotsHost(slotSize, alloc);
+      }
+    };
+
+    template<class T_Allocator>
+    struct GetAvailableSlotsIfAvail<T_Allocator, false, true>
+    {
+      MAMC_ACCELERATOR
+      static unsigned
+      getAvailableSlots(size_t slotSize, T_Allocator& alloc){
+          return alloc.getAvailableSlotsAccelerator(slotSize);
       }
     };
 
@@ -177,19 +183,6 @@ namespace mallocMC{
         heapInfos.p=pool;
         heapInfos.size=size;
 
-        /*
-        * This is a workaround for a bug with getAvailSlotsPoly:
-        * Due to some problems with conditional compilation (possibly a CUDA bug),
-        * getAvailableSlotsHost must explicitly be used from inside a host
-        * function at least once. Doing it here guarantees that it is executed
-        * and that this execution happens on the host. Usually, simply defining
-        * this inside a host function (without actually executing it) would be
-        * sufficient. However, due to the template nature of policy based
-        * design, functions are only compiled if they are actually used.
-        */
-        detail::GetAvailableSlotsIfAvail<boost::mpl::bool_<CreationPolicy::providesAvailableSlots::value> >
-          ::getAvailableSlots(1024, *this); //actual slot size does not matter
-
         return h;
       }
 
@@ -211,13 +204,20 @@ namespace mallocMC{
       }
 
 
-      // polymorphism over the availability of getAvailableSlots
-      MAMC_HOST MAMC_ACCELERATOR
+      // polymorphism over the availability of getAvailableSlots for calling from the host
+      MAMC_HOST
       unsigned getAvailableSlots(size_t slotSize){
         slotSize = AlignmentPolicy::applyPadding(slotSize);
 
-        return detail::GetAvailableSlotsIfAvail<boost::mpl::bool_<CreationPolicy::providesAvailableSlots::value> >
-          ::getAvailableSlots(slotSize, *this);
+        return detail::GetAvailableSlotsIfAvail<Allocator, true>::getAvailableSlots(slotSize, *this);
+      }
+
+      // polymorphism over the availability of getAvailableSlots for calling from the accelerator
+      MAMC_ACCELERATOR
+      unsigned getAvailableSlotsAccelerator(size_t slotSize){
+        slotSize = AlignmentPolicy::applyPadding(slotSize);
+
+        return detail::GetAvailableSlotsIfAvail<Allocator, false>::getAvailableSlots(slotSize, *this);
       }
 
       MAMC_HOST
@@ -230,3 +230,4 @@ namespace mallocMC{
   };
 
 } //namespace mallocMC
+

--- a/src/include/mallocMC/mallocMC_overwrites.hpp
+++ b/src/include/mallocMC/mallocMC_overwrites.hpp
@@ -70,16 +70,22 @@ MAMC_HOST void finalizeHeap(                                                    
  */
 #define MALLOCMC_AVAILABLESLOTS()                                               \
 namespace mallocMC{                                                             \
-MAMC_HOST MAMC_ACCELERATOR                                                       \
-unsigned getAvailableSlots(                                                    \
-    size_t slotSize,                                                           \
-    mallocMCType &p = mallocMCGlobalObject){                                     \
-    return p.getAvailableSlots(slotSize);                                      \
-}                                                                              \
-MAMC_HOST MAMC_ACCELERATOR                                                       \
-bool providesAvailableSlots(){                                                 \
+MAMC_HOST                                                                       \
+unsigned getAvailableSlots(                                                     \
+    size_t slotSize,                                                            \
+    mallocMCType &p = mallocMCGlobalObject){                                    \
+    return p.getAvailableSlots(slotSize);                                       \
+}                                                                               \
+MAMC_ACCELERATOR                                                                \
+unsigned getAvailableSlotsAccelerator(                                          \
+    size_t slotSize,                                                            \
+    mallocMCType &p = mallocMCGlobalObject){                                    \
+    return p.getAvailableSlotsAccelerator(slotSize);                            \
+}                                                                               \
+MAMC_HOST MAMC_ACCELERATOR                                                      \
+bool providesAvailableSlots(){                                                  \
     return Traits<mallocMCType>::providesAvailableSlots;                        \
-}                                                                              \
+}                                                                               \
 } /* end namespace mallocMC */
 
 


### PR DESCRIPTION
Fixes #106 

This makes getAvailableSlots a host only function (most common case) and adds a function getAvailableSlotsAccelerator for device side calls. It allows also the removal of the workaround in initHeap