### PR TITLE
Use BOOST_STATIC_CONSTEXPR where possible

### DIFF
--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -72,7 +72,7 @@ namespace Shrink2NS{
 #ifndef MALLOCMC_AP_SHRINK_DATAALIGNMENT
 #define MALLOCMC_AP_SHRINK_DATAALIGNMENT Properties::dataAlignment::value
 #endif
-    static const uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
+    BOOST_STATIC_CONSTEXPR uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
 
     // \TODO: The static_cast can be removed once the minimal dependencies of
     //        this project is are at least CUDA 7.0 and gcc 4.8.2

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -96,66 +96,66 @@ namespace ScatterKernelDetail{
 #ifndef MALLOCMC_CP_SCATTER_PAGESIZE
 #define MALLOCMC_CP_SCATTER_PAGESIZE  static_cast<uint32>(HeapProperties::pagesize::value)
 #endif
-      static const uint32 pagesize      = MALLOCMC_CP_SCATTER_PAGESIZE;
+      BOOST_STATIC_CONSTEXPR uint32 pagesize      = MALLOCMC_CP_SCATTER_PAGESIZE;
 
 #ifndef MALLOCMC_CP_SCATTER_ACCESSBLOCKS
 #define MALLOCMC_CP_SCATTER_ACCESSBLOCKS static_cast<uint32>(HeapProperties::accessblocks::value)
 #endif
-      static const uint32 accessblocks  = MALLOCMC_CP_SCATTER_ACCESSBLOCKS;
+      BOOST_STATIC_CONSTEXPR uint32 accessblocks  = MALLOCMC_CP_SCATTER_ACCESSBLOCKS;
 
 #ifndef MALLOCMC_CP_SCATTER_REGIONSIZE
 #define MALLOCMC_CP_SCATTER_REGIONSIZE static_cast<uint32>(HeapProperties::regionsize::value)
 #endif
-      static const uint32 regionsize    = MALLOCMC_CP_SCATTER_REGIONSIZE;
+      BOOST_STATIC_CONSTEXPR uint32 regionsize    = MALLOCMC_CP_SCATTER_REGIONSIZE;
 
 #ifndef MALLOCMC_CP_SCATTER_WASTEFACTOR
 #define MALLOCMC_CP_SCATTER_WASTEFACTOR static_cast<uint32>(HeapProperties::wastefactor::value)
 #endif
-      static const uint32 wastefactor   = MALLOCMC_CP_SCATTER_WASTEFACTOR;
+      BOOST_STATIC_CONSTEXPR uint32 wastefactor   = MALLOCMC_CP_SCATTER_WASTEFACTOR;
 
 #ifndef MALLOCMC_CP_SCATTER_RESETFREEDPAGES
 #define MALLOCMC_CP_SCATTER_RESETFREEDPAGES static_cast<bool>(HeapProperties::resetfreedpages::value)
 #endif
-      static const bool resetfreedpages = MALLOCMC_CP_SCATTER_RESETFREEDPAGES;
+      BOOST_STATIC_CONSTEXPR bool resetfreedpages = MALLOCMC_CP_SCATTER_RESETFREEDPAGES;
 
 
     public:
-      static const uint32 _pagesize       = pagesize;
-      static const uint32 _accessblocks   = accessblocks;
-      static const uint32 _regionsize     = regionsize;
-      static const uint32 _wastefactor    = wastefactor;
-      static const bool _resetfreedpages  = resetfreedpages;
+      BOOST_STATIC_CONSTEXPR uint32 _pagesize       = pagesize;
+      BOOST_STATIC_CONSTEXPR uint32 _accessblocks   = accessblocks;
+      BOOST_STATIC_CONSTEXPR uint32 _regionsize     = regionsize;
+      BOOST_STATIC_CONSTEXPR uint32 _wastefactor    = wastefactor;
+      BOOST_STATIC_CONSTEXPR bool _resetfreedpages  = resetfreedpages;
 
     private:
 #if _DEBUG || ANALYSEHEAP
     public:
 #endif
-      //static const uint32 minChunkSize0 = pagesize/(32*32);
-      static const uint32 minChunkSize1 = 0x10;
-      static const uint32 HierarchyThreshold =  (pagesize - 2*sizeof(uint32))/33;
-      static const uint32 minSegmentSize = 32*minChunkSize1 + sizeof(uint32);
-      static const uint32 tmp_maxOPM = minChunkSize1 > HierarchyThreshold ? 0 : (pagesize + (minSegmentSize-1)) / minSegmentSize;
-      static const uint32 maxOnPageMasks = 32 > tmp_maxOPM ? tmp_maxOPM : 32;
+      //BOOST_STATIC_CONSTEXPR uint32 minChunkSize0 = pagesize/(32*32);
+      BOOST_STATIC_CONSTEXPR uint32 minChunkSize1 = 0x10;
+      BOOST_STATIC_CONSTEXPR uint32 HierarchyThreshold =  (pagesize - 2*sizeof(uint32))/33;
+      BOOST_STATIC_CONSTEXPR uint32 minSegmentSize = 32*minChunkSize1 + sizeof(uint32);
+      BOOST_STATIC_CONSTEXPR uint32 tmp_maxOPM = minChunkSize1 > HierarchyThreshold ? 0 : (pagesize + (minSegmentSize-1)) / minSegmentSize;
+      BOOST_STATIC_CONSTEXPR uint32 maxOnPageMasks = 32 > tmp_maxOPM ? tmp_maxOPM : 32;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGK
 #define MALLOCMC_CP_SCATTER_HASHINGK    static_cast<uint32>(HashingProperties::hashingK::value)
 #endif
-     static const uint32 hashingK       = MALLOCMC_CP_SCATTER_HASHINGK;
+     BOOST_STATIC_CONSTEXPR uint32 hashingK       = MALLOCMC_CP_SCATTER_HASHINGK;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTMP
 #define MALLOCMC_CP_SCATTER_HASHINGDISTMP static_cast<uint32>(HashingProperties::hashingDistMP::value)
 #endif
-     static const uint32 hashingDistMP  = MALLOCMC_CP_SCATTER_HASHINGDISTMP;
+     BOOST_STATIC_CONSTEXPR uint32 hashingDistMP  = MALLOCMC_CP_SCATTER_HASHINGDISTMP;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTWP
 #define MALLOCMC_CP_SCATTER_HASHINGDISTWP static_cast<uint32>(HashingProperties::hashingDistWP::value)
 #endif
-     static const uint32 hashingDistWP  = MALLOCMC_CP_SCATTER_HASHINGDISTWP;
+     BOOST_STATIC_CONSTEXPR uint32 hashingDistWP  = MALLOCMC_CP_SCATTER_HASHINGDISTWP;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTWPREL
 #define MALLOCMC_CP_SCATTER_HASHINGDISTWPREL static_cast<uint32>(HashingProperties::hashingDistWPRel::value)
 #endif
-     static const uint32 hashingDistWPRel = MALLOCMC_CP_SCATTER_HASHINGDISTWPREL;
+     BOOST_STATIC_CONSTEXPR uint32 hashingDistWPRel = MALLOCMC_CP_SCATTER_HASHINGDISTWPREL;
 
 
       /**

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -73,7 +73,7 @@ namespace DistributionPolicies{
 #ifndef MALLOCMC_DP_XMALLOCSIMD_PAGESIZE
 #define MALLOCMC_DP_XMALLOCSIMD_PAGESIZE Properties::pagesize::value
 #endif
-      static const uint32 pagesize      = MALLOCMC_DP_XMALLOCSIMD_PAGESIZE;
+      BOOST_STATIC_CONSTEXPR uint32 pagesize      = MALLOCMC_DP_XMALLOCSIMD_PAGESIZE;
 
       //all the properties must be unsigned integers > 0
       BOOST_STATIC_ASSERT(!std::numeric_limits<typename Properties::pagesize::type>::is_signed);
@@ -83,7 +83,7 @@ namespace DistributionPolicies{
       BOOST_STATIC_ASSERT(static_cast<uint32>(pagesize) > 0);
 
     public:
-      static const uint32 _pagesize = pagesize;
+      BOOST_STATIC_CONSTEXPR uint32 _pagesize = pagesize;
 
       MAMC_ACCELERATOR
       uint32 collect(uint32 bytes){

--- a/src/include/mallocMC/mallocMC_traits.hpp
+++ b/src/include/mallocMC/mallocMC_traits.hpp
@@ -32,7 +32,7 @@ namespace mallocMC{
 
     template <class T_Allocator>
     struct  Traits{
-        static const bool providesAvailableSlots = T_Allocator::CreationPolicy::providesAvailableSlots::value;
+        BOOST_STATIC_CONSTEXPR bool providesAvailableSlots = T_Allocator::CreationPolicy::providesAvailableSlots::value;
     };
 
 } //namespace mallocMC

--- a/tests/verify_heap.cu
+++ b/tests/verify_heap.cu
@@ -73,9 +73,9 @@ std::ostream& dout() {
 }
 
 // define some defaults
-static const unsigned threads_default = 128;
-static const unsigned blocks_default  = 64; 
-static const size_t heapInMB_default  = 1024; // 1GB
+BOOST_STATIC_CONSTEXPR unsigned threads_default = 128;
+BOOST_STATIC_CONSTEXPR unsigned blocks_default  = 64; 
+BOOST_STATIC_CONSTEXPR size_t heapInMB_default  = 1024; // 1GB
 
 
 /**


### PR DESCRIPTION
This uses BOOST_STATIC_CONSTEXPR instead of `static const` for C++11 compatibility although it seems to work without that too. But to avoid future problems I still added that.

Merge *AFTER* #107