### PR TITLE
Fixed problems leading to uninitialized pointers

### DIFF
--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -75,10 +75,8 @@ namespace CUDA
 
   inline void checkError(cudaError errorValue, const char* file, int line)
   {
-#ifdef _DEBUG
     if (errorValue != cudaSuccess)
       throw CUDA::error(errorValue, file, line);
-#endif
   }
 
   inline void checkError(const char* file, int line)
@@ -88,11 +86,9 @@ namespace CUDA
 
   inline void checkError()
   {
-#ifdef _DEBUG
     cudaError errorValue = cudaGetLastError();
     if (errorValue != cudaSuccess)
       throw CUDA::error(errorValue);
-#endif
   }
 
 #define MALLOCMC_CUDA_CHECKED_CALL(call) CUDA::checkError(call, __FILE__, __LINE__)

--- a/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
@@ -38,7 +38,7 @@ namespace ReservePoolPolicies{
 
   struct SimpleCudaMalloc{
     static void* setMemPool(size_t memsize){
-      void* pool;
+      void* pool = NULL;
       MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc(&pool, memsize));
       return pool;
     }


### PR DESCRIPTION
 - CUDA::checkError now throws always
 - pointer in SimpleCudaMalloc::setMemPool is initialized
 - fixes #110