### PR TITLE
Updating to Travis-CI Trusty Beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: cpp
 
+sudo: required
+
+dist: trusty
+
 compiler:
   - gcc
 
@@ -15,17 +19,20 @@ script:
   - make examples
 
 before_script:
-  - sudo add-apt-repository --yes ppa:smspillaz/cmake-2.8.12
+  - cat /etc/apt/sources.list
+  - cat /etc/apt/sources.list.d/*
+  - sudo apt-add-repository multiverse
   - sudo apt-get update -qq
+  - sudo dpkg --configure -a
+  - sudo apt-get install -f -qq
+  - sudo dpkg --get-selections | grep hold || { echo "All packages OK."; }
   - sudo apt-get install -q -y cmake-data cmake
   - sudo apt-get install -qq build-essential
-  - sudo apt-get install -qq gcc-4.4 g++-4.4
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.4 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.4
-  - gcc --version && g++ --version
+  - gcc --version && g++ --version # 4.8
+  - apt-cache search nvidia-*
   - sudo apt-get install -qq nvidia-common
-  - sudo apt-get install -qq nvidia-current
-  - sudo apt-get install -qq nvidia-cuda-toolkit nvidia-cuda-dev
-  - sudo apt-get install -qq libboost1.48-dev
+  - sudo apt-get install -qq nvidia-cuda-dev nvidia-cuda-toolkit # 5.5
+  - sudo apt-get install -qq libboost-dev # 1.54.0
   - sudo find /usr/ -name libcuda*.so
 
 after_script:


### PR DESCRIPTION
GCC 4.8.2 + CUDA 5.5 + Native CMake 2.8.12.2 Images

I am not sure if it is relevant, since for some reasons travis-ci just worked again yesterday.

Maybe it is not too bad to have an old CUDA and GCC version tested automatically. Nevertheless, if we should need a newer version at some point, here is a new image without PPA's.