### PR TITLE
Fix: Includes from C headers

### DIFF
--- a/examples/mallocMC_example01.cu
+++ b/examples/mallocMC_example01.cu
@@ -27,7 +27,7 @@
 */
 
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <vector>
 #include <numeric>
 

--- a/examples/mallocMC_example02.cu
+++ b/examples/mallocMC_example02.cu
@@ -27,7 +27,7 @@
 */
 
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <vector>
 #include <numeric>
 

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#include <stdio.h>
+#include <cstdio>
 #include <boost/cstdint.hpp> /* uint32_t */
 #include <iostream>
 #include <string>

--- a/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#include <assert.h>
+#include <cassert>
 #include <string>
 
 #include "BadAllocException.hpp"

--- a/tests/verify_heap.cu
+++ b/tests/verify_heap.cu
@@ -42,7 +42,7 @@
 
 #include <cuda.h>
 #include <iostream>
-#include <stdio.h>
+#include <cstdio>
 #include <typeinfo>
 #include <vector>
 


### PR DESCRIPTION
Use correct `<c...>` includes in C++.

Only thing I was not sure about because it seems to be non-std:
```
./src/include/mallocMC/mallocMC_utils.hpp :

```

@slizzered 