### PR TITLE
Close #120 Missing '%%' for PTX Special Register

### DIFF
--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -129,68 +129,68 @@ namespace mallocMC
   MAMC_ACCELERATOR inline boost::uint32_t laneid()
   {
     boost::uint32_t mylaneid;
-    asm("mov.u32 %0, %laneid;" : "=r" (mylaneid));
+    asm("mov.u32 %0, %%laneid;" : "=r" (mylaneid));
     return mylaneid;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t warpid()
   {
     boost::uint32_t mywarpid;
-    asm("mov.u32 %0, %warpid;" : "=r" (mywarpid));
+    asm("mov.u32 %0, %%warpid;" : "=r" (mywarpid));
     return mywarpid;
   }
   MAMC_ACCELERATOR inline boost::uint32_t nwarpid()
   {
     boost::uint32_t mynwarpid;
-    asm("mov.u32 %0, %nwarpid;" : "=r" (mynwarpid));
+    asm("mov.u32 %0, %%nwarpid;" : "=r" (mynwarpid));
     return mynwarpid;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t smid()
   {
     boost::uint32_t mysmid;
-    asm("mov.u32 %0, %smid;" : "=r" (mysmid));
+    asm("mov.u32 %0, %%smid;" : "=r" (mysmid));
     return mysmid;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t nsmid()
   {
     boost::uint32_t mynsmid;
-    asm("mov.u32 %0, %nsmid;" : "=r" (mynsmid));
+    asm("mov.u32 %0, %%nsmid;" : "=r" (mynsmid));
     return mynsmid;
   }
   MAMC_ACCELERATOR inline boost::uint32_t lanemask()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_eq;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_eq;" : "=r" (lanemask));
     return lanemask;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t lanemask_le()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_le;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_le;" : "=r" (lanemask));
     return lanemask;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t lanemask_lt()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_lt;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_lt;" : "=r" (lanemask));
     return lanemask;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t lanemask_ge()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_ge;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_ge;" : "=r" (lanemask));
     return lanemask;
   }
 
   MAMC_ACCELERATOR inline boost::uint32_t lanemask_gt()
   {
     boost::uint32_t lanemask;
-    asm("mov.u32 %0, %lanemask_gt;" : "=r" (lanemask));
+    asm("mov.u32 %0, %%lanemask_gt;" : "=r" (lanemask));
     return lanemask;
   }
 


### PR DESCRIPTION
Close #120: assembler ptx command: add `%%` to use the laneid register

This changes is needed to compile with `clang++`, `nvcc` is relaxed and accept the special register also with one `%`.
Helpful [link](http://stackoverflow.com/a/40205665) with the explanation why we need to use `%%`
