### PR TITLE
fix missing local size change in `finalizeHeap()`

### DIFF
--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -174,6 +174,7 @@ namespace detail{
             CreationPolicy::finalizeHeap( allocatorHandle.devAllocator, heapInfos.p );
             cudaFree( allocatorHandle.devAllocator );
             ReservePoolPolicy::resetMemPool( heapInfos.p );
+            heapInfos.size = 0;
         }
 
         MAMC_HOST


### PR DESCRIPTION
`finalizeHeap()` set internet pool size to zero

After call to `finalizeHeap()` the method `getHeapLocations()` provide a wrong (the old) pool size to the user.