### PR TITLE
fix `finalizeHeap`

### DIFF
--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -199,9 +199,7 @@ namespace detail{
         finalizeHeap( )
         {
             CreationPolicy::finalizeHeap( allocatorHandle.devAllocator, heapInfos.p );
-            cudaFree( allocatorHandle.devAllocator );
             ReservePoolPolicy::resetMemPool( heapInfos.p );
-            heapInfos.size = 0;
         }
 
         MAMC_HOST


### PR DESCRIPTION
- device handle is destroyed and can used with invalid memory
- revert #135 because `finalizeHeap()` only clear the memory