### PR TITLE
self consistent allocator

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -13,7 +13,7 @@ There is one header file that will include *all* necessary files:
 Step 2a: choose policies
 -----------------------
 
-Each instance of a policy based allocator is composed through 5 **policies**. Each policy is expressed as a **policy class**. 
+Each instance of a policy based allocator is composed through 5 **policies**. Each policy is expressed as a **policy class**.
 
 Currently, there are the following policy classes available:
 
@@ -73,7 +73,7 @@ could create the following typedef instead:
 ```c++
 using namespace mallocMC;
 
-typedef mallocMC::Allocator< 
+typedef mallocMC::Allocator<
   CreationPolicies::Scatter<>,
   DistributionPolicies::XMallocSIMD<>,
   OOMPolicies::ReturnNull,
@@ -98,29 +98,22 @@ ScatterAllocator sa( 512U * 1024U * 1024U ); // heap size of 512MiB
 
 The allocator object offers the following methods
 
-| Name | description | 
+| Name | description |
 |---------------------- |-------------------------|
 | getAvailableSlots(size_t)   | Determines number of allocatable slots of a certain size. This only works, if the chosen CreationPolicy supports it (can be found through `mallocMC::Traits<ScatterAllocator>::providesAvailableSlots`) |
-| finalizeHeap()     | Frees the heap on the accelerator |   
-
-Note, that the heap needs to be freed explicitly after it is no longer used:
-
-```c++
-sa.finalizeHeap();
-```
 
 
 Step 4: use dynamic memory allocation in a kernel
 -------------------------------------------------
 
-A handle to the allocator object must be passed to each kernel. The handle type is defined as an internal type of the allocator. Inside the kernel, this handle can be used to request memory.  
+A handle to the allocator object must be passed to each kernel. The handle type is defined as an internal type of the allocator. Inside the kernel, this handle can be used to request memory.
 
 The handle offers the following methods:
 
-| Name | description | 
+| Name | description |
 |---------------------- |-------------------------|
-| malloc(size_t) | Allocates memory on the accelerator  |   
-| free(size_t)     | Frees memory on the accelerator    |   
+| malloc(size_t) | Allocates memory on the accelerator  |
+| free(size_t)     | Frees memory on the accelerator    |
 | getAvailableSlots()   | Determines number of allocatable slots of a certain size. This only works, if the chosen CreationPolicy supports it (can be found through `mallocMC::Traits<ScatterAllocator>::providesAvailableSlots`) |
 
 A simplistic example would look like this:
@@ -129,7 +122,7 @@ A simplistic example would look like this:
 
 namespace mallocMC = MC;
 
-typedef MC::Allocator< 
+typedef MC::Allocator<
   MC::CreationPolicies::Scatter<>,
   MC::DistributionPolicies::XMallocSIMD<>,
   MC::OOMPolicies::ReturnNull,
@@ -140,11 +133,11 @@ typedef MC::Allocator<
 __global__ exampleKernel(ScatterAllocator::AllocatorHandle sah)
 {
   // some code ...
-  
+
   int* a = (int*) sah.malloc(sizeof(int)*42);
-  
+
   // some more code, using *a
-  
+
   sah.free(a);
 }
 
@@ -152,7 +145,6 @@ int main(){
   ScatterAllocator sa( 1U * 512U * 1024U * 1024U ); // heap size of 512MiB
   exampleKernel<<< 32, 32 >>>(sa);
 
-  sa.finalizeHeap();
   return 0;
 }
 ```

--- a/examples/mallocMC_example01.cu
+++ b/examples/mallocMC_example01.cu
@@ -153,6 +153,4 @@ void run()
   freeArrayPointers<<<1,1>>>( mMC );
   cudaFree(d);
 
-  //finalize the heap again
-  mMC.finalizeHeap();
 }

--- a/examples/mallocMC_example02.cu
+++ b/examples/mallocMC_example02.cu
@@ -216,6 +216,4 @@ void run()
     freeArrayPointers<<<1, 1>>>( mMC );
     cudaFree(d);
 
-    //finalize the heap again
-    mMC.finalizeHeap();
 }

--- a/examples/mallocMC_example03.cu
+++ b/examples/mallocMC_example03.cu
@@ -115,6 +115,5 @@ int main()
     exampleKernel<<<1,32>>>( mMC );
     std::cout << "Slots from Host: " << mMC.getAvailableSlots(1) << std::endl;
 
-    mMC.finalizeHeap();
     return 0;
 }

--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -168,6 +168,25 @@ namespace detail{
             heapInfos.size = size;
         }
 
+        /** free all data structures
+         *
+         * Free all allocated memory.
+         * After this call the instance is an in invalid state
+         */
+        MAMC_HOST
+        void free()
+        {
+            cudaFree( allocatorHandle.devAllocator );
+            ReservePoolPolicy::resetMemPool( heapInfos.p );
+            allocatorHandle.devAllocator = NULL;
+            heapInfos.size = 0;
+            heapInfos.p = NULL;
+        }
+
+        /* forbid to copy the allocator */
+        MAMC_HOST
+        Allocator( const Allocator& );
+
     public:
 
 
@@ -180,6 +199,12 @@ namespace detail{
             alloc( size );
         }
 
+        MAMC_HOST
+        ~Allocator( )
+        {
+            free( );
+        }
+
         /** destroy current heap data and resize the heap
          *
          * @param size number of bytes
@@ -190,18 +215,8 @@ namespace detail{
             size_t size
         )
         {
-            finalizeHeap( );
+            free( );
             alloc( size );
-        }
-
-        MAMC_HOST
-        void
-        finalizeHeap( )
-        {
-            CreationPolicy::finalizeHeap( allocatorHandle.devAllocator, heapInfos.p );
-            cudaFree( allocatorHandle.devAllocator );
-            ReservePoolPolicy::resetMemPool( heapInfos.p );
-            heapInfos.size = 0;
         }
 
         MAMC_HOST

--- a/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
@@ -61,11 +61,6 @@ namespace CreationPolicies{
       return dAlloc;
     }
 
-    template < typename T>
-    static void finalizeHeap(const T*, void*){
-      return;
-    }
-
     static std::string classname(){
       return "OldMalloc";
     }


### PR DESCRIPTION
With `finalizeHeap` it is possible that the user can create an invalid allocator and access invalid memory.
Wrong usage can be avoided by removing this method and forbid the copy constructor.

- allocator.hpp
  - remove `finalizeHeap()`
  - add private `free()` method
  - forbid copy constructor
  - add destructor
- update `Usage.md`
- creationPolicies: remove `finalizeHeap`
  - it is not possible to implement a `reset` function for each `creationPolicy` e.g. `OldMalloc`
- update examples and tests