### PR TITLE
Traits: Missing Boost Include

### DIFF
--- a/src/include/mallocMC/mallocMC_traits.hpp
+++ b/src/include/mallocMC/mallocMC_traits.hpp
@@ -28,6 +28,9 @@
 
 #pragma once
 
+#include <boost/config.hpp>
+
+
 namespace mallocMC{
 
     template <class T_Allocator>


### PR DESCRIPTION
Adds the missing include for `BOOST_STATIC_CONSTEXPR`.

http://www.boost.org/doc/libs/1_64_0/libs/config/doc/html/boost_config/boost_macro_reference.html

Reproduce:
```C++
#include <boost/version.hpp>
// mallocMC bug
// include <boost/config.hpp>

#include <cuda.h>
#include <mallocMC/mallocMC.hpp>
```