### PR TITLE
support for CUDA9 `__ballot_sync`

### DIFF
--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -100,8 +100,11 @@ namespace DistributionPolicies{
         //second half: make sure that all coalesced allocations can fit within one page
         //necessary for offset calculation
         bool coalescible = bytes > 0 && bytes < (pagesize / 32);
+#if(__CUDACC_VER_MAJOR__ >= 9)
+        threadcount = __popc(__ballot_sync(0xFFFFFFFF, coalescible));
+#else
         threadcount = __popc(__ballot(coalescible));
-
+#endif
         if (coalescible && threadcount > 1)
         {
           myoffset = atomicAdd(&warp_sizecounter[warpid], bytes);

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -96,18 +96,7 @@ namespace CUDA
 }
 
 
-#define warp_serial                                    \
-  for (unsigned int __mask = __ballot(1),              \
-            __num = __popc(__mask),                    \
-            __lanemask = mallocMC::lanemask_lt(),      \
-            __local_id = __popc(__lanemask & __mask),  \
-            __active = 0;                              \
-       __active < __num;                               \
-       ++__active)                                     \
-    if (__active == __local_id)
-
-
-namespace mallocMC 
+namespace mallocMC
 {
 
   template<int PSIZE>


### PR DESCRIPTION
- use `ballot_sync` if CUDA9 is used
- copy code of precompiler function `warp_serial` to the used function

This PR will remove the warning: `mallocMC/src/include/mallocMC/creationPolicies/Scatter_impl.hpp(620): warning: function "__ballot"`