### PR TITLE
Fix V100 Active Lanes in Warp

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -619,7 +619,7 @@ namespace ScatterKernelDetail{
         void* res = 0;
         for(
 #if(__CUDACC_VER_MAJOR__ >= 9)
-          unsigned int __mask = __ballot_sync(0xFFFFFFFF, 1),
+          unsigned int __mask = __activemask(),
 #else
           unsigned int __mask = __ballot(1),
 #endif
@@ -936,7 +936,7 @@ namespace ScatterKernelDetail{
         int wId = threadIdx.x >> 5; //do not use warpid-function, since this value is not guaranteed to be stable across warp lifetime
 
 #if(__CUDACC_VER_MAJOR__ >= 9)
-        uint32 activeThreads  = __popc(__ballot_sync(0xFFFFFFFF, true));
+        uint32 activeThreads  = __popc(__activemask());
 #else
         uint32 activeThreads  = __popc(__ballot(true));
 #endif

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -101,7 +101,7 @@ namespace DistributionPolicies{
         //necessary for offset calculation
         bool coalescible = bytes > 0 && bytes < (pagesize / 32);
 #if(__CUDACC_VER_MAJOR__ >= 9)
-        threadcount = __popc(__ballot_sync(0xFFFFFFFF, coalescible));
+        threadcount = __popc(__ballot_sync(__activemask(), coalescible));
 #else
         threadcount = __popc(__ballot(coalescible));
 #endif


### PR DESCRIPTION
Fix for V100 and CUDA 9.0 ballot functions, introduced in #144.
Properly use the currently active mask of lanes in a warp instead of a constant.

We have seen deadlocks in [PIConGPU/PMacc](https://github.com/ComputationalRadiationPhysics/picongpu/pull/2600) with when using the `FULL_MASK` (`0xFFFFFFFF`). This can cause deadlocks e.g. in branched threads which are properly described with `__activemask()` instead.

https://devblogs.nvidia.com/using-cuda-warp-level-primitives/