### PR TITLE
fix illegal memory access

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -933,15 +933,15 @@ namespace ScatterKernelDetail{
        */
       __device__ unsigned getAvailableSlotsAccelerator(size_t slotSize){
         int linearId;
-        int wId = threadIdx.x >> 5; //do not use warpid-function, since this value is not guaranteed to be stable across warp lifetime
+        int wId = warpid_withinblock(); //do not use warpid-function, since this value is not guaranteed to be stable across warp lifetime
 
 #if(__CUDACC_VER_MAJOR__ >= 9)
         uint32 activeThreads  = __popc(__activemask());
 #else
         uint32 activeThreads  = __popc(__ballot(true));
 #endif
-        __shared__ uint32 activePerWarp[32]; //32 is the maximum number of warps in a block
-        __shared__ unsigned warpResults[32];
+        __shared__ uint32 activePerWarp[MaxThreadsPerBlock::value / WarpSize::value]; //maximum number of warps in a block
+        __shared__ unsigned warpResults[MaxThreadsPerBlock::value / WarpSize::value];
         warpResults[wId]   = 0;
         activePerWarp[wId] = 0;
 

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -60,6 +60,11 @@ namespace DistributionPolicies{
     public:
       typedef T_Config Properties;
 
+	  MAMC_ACCELERATOR
+	  XMallocSIMD() : can_use_coalescing(false), warpid(warpid_withinblock()),
+		myoffset(0), threadcount(0), req_size(0)
+	  {}
+
     private:
 /** Allow for a hierarchical validation of parameters:
  *
@@ -89,12 +94,11 @@ namespace DistributionPolicies{
       uint32 collect(uint32 bytes){
 
         can_use_coalescing = false;
-        warpid = mallocMC::warpid();
         myoffset = 0;
         threadcount = 0;
 
         //init with initial counter
-        __shared__ uint32 warp_sizecounter[32];
+        __shared__ uint32 warp_sizecounter[MaxThreadsPerBlock::value / WarpSize::value];
         warp_sizecounter[warpid] = 16;
 
         //second half: make sure that all coalesced allocations can fit within one page
@@ -121,7 +125,7 @@ namespace DistributionPolicies{
 
       MAMC_ACCELERATOR
       void* distribute(void* allocatedMem){
-        __shared__ char* warp_res[32];
+        __shared__ char* warp_res[MaxThreadsPerBlock::value / WarpSize::value];
 
         char* myalloc = (char*) allocatedMem;
         if (req_size && can_use_coalescing)

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -60,10 +60,10 @@ namespace DistributionPolicies{
     public:
       typedef T_Config Properties;
 
-	  MAMC_ACCELERATOR
-	  XMallocSIMD() : can_use_coalescing(false), warpid(warpid_withinblock()),
-		myoffset(0), threadcount(0), req_size(0)
-	  {}
+      MAMC_ACCELERATOR
+      XMallocSIMD() : can_use_coalescing(false), warpid(warpid_withinblock()),
+        myoffset(0), threadcount(0), req_size(0)
+      {}
 
     private:
 /** Allow for a hierarchical validation of parameters:

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -122,12 +122,24 @@ namespace mallocMC
     return mylaneid;
   }
 
+  /** warp index within a multiprocessor
+   *
+   * Index of the warp within the multiprocessor at the moment of the query.
+   * The result is volatile and can be different with each query.
+   *
+   * @return current index of the warp
+   */
   MAMC_ACCELERATOR inline boost::uint32_t warpid()
   {
     boost::uint32_t mywarpid;
     asm("mov.u32 %0, %%warpid;" : "=r" (mywarpid));
     return mywarpid;
   }
+
+  /** maximum number of warps on a multiprocessor
+   *
+   * @return maximum number of warps on a multiprocessor
+   */
   MAMC_ACCELERATOR inline boost::uint32_t nwarpid()
   {
     boost::uint32_t mynwarpid;
@@ -192,23 +204,23 @@ namespace mallocMC
    */
   struct MaxThreadsPerBlock
   {
-	// valid for sm_2.X - sm_7.5
-    BOOST_STATIC_ASSERT uint32_t value = 1024;
+    // valid for sm_2.X - sm_7.5
+    BOOST_STATIC_CONSTEXPR uint32_t value = 1024;
   };
 
-  /** the maximal number threads per block
+  /** number of threads within a warp
    *
    * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities
    */
   struct WarpSize
   {
-	// valid for sm_2.X - sm_7.5
-    BOOST_STATIC_ASSERT uint32_t value = 32;
+    // valid for sm_2.X - sm_7.5
+    BOOST_STATIC_CONSTEXPR uint32_t value = 32;
   };
 
-  /** warp id within a block
+  /** warp id within a cuda block
    *
-   * The id is constant over the livetime of the thread.
+   * The id is constant over the lifetime of the thread.
    * The id is not equal to warpid().
    *
    * @return warp id within the block
@@ -218,7 +230,7 @@ namespace mallocMC
     return (
       threadIdx.z * blockDim.y * blockDim.x +
       threadIdx.y * blockDim.x +
-	  threadIdx.x
+      threadIdx.x
     ) / WarpSize::value;
   }
 }

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -186,4 +186,39 @@ namespace mallocMC
   template<class T>
   MAMC_HOST MAMC_ACCELERATOR inline T divup(T a, T b) { return (a + b - 1)/b; }
 
+  /** the maximal number threads per block
+   *
+   * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities
+   */
+  struct MaxThreadsPerBlock
+  {
+	// valid for sm_2.X - sm_7.5
+    BOOST_STATIC_ASSERT uint32_t value = 1024;
+  };
+
+  /** the maximal number threads per block
+   *
+   * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities
+   */
+  struct WarpSize
+  {
+	// valid for sm_2.X - sm_7.5
+    BOOST_STATIC_ASSERT uint32_t value = 32;
+  };
+
+  /** warp id within a block
+   *
+   * The id is constant over the livetime of the thread.
+   * The id is not equal to warpid().
+   *
+   * @return warp id within the block
+   */
+  MAMC_ACCELERATOR inline boost::uint32_t warpid_withinblock()
+  {
+    return (
+      threadIdx.z * blockDim.y * blockDim.x +
+      threadIdx.y * blockDim.x +
+	  threadIdx.x
+    ) / WarpSize::value;
+  }
 }


### PR DESCRIPTION
fix #149

The number of warps per multiprocessor depends on the architecture.
In some places, the warp id was used to access block shared memory with a fixed size of 32.
Since sm_20 the number of warps per multiprocessor is 64 which can create an out of memory access.

- add helper methods for:
  - MaxThreadsPerBlock
  - WarpSize
  - warpid_withinblock()
- fix collective warp aggregations