### PR TITLE
Make: Honor _ROOT Env Hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,22 @@
 project(mallocMC)
 cmake_minimum_required(VERSION 2.8.12.2)
 
+################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+################################################################################
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+
+################################################################################
+# Common.
+################################################################################
+
 # helper for libs and packages
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/"
     "$ENV{CUDA_ROOT}" "$ENV{BOOST_ROOT}")


### PR DESCRIPTION
CMake 3.12.0+ honor <Package>_ROOT environment hints which are often set on HPC systems. Previously, it was only looking for <Package>_DIR paths in find_package calls.

This new policy is useful since HPC systems usually set _DIR, _ROOT or expand the CMAKE_PREFIX_PATH. Therefore we want to use it as soon as it is available.

On systems where those env vars are set, e.g. Hypnos, this also throws a warning if the default (OLD) policy is used with CMake 3.12.4 or newer.

References:

https://cmake.org/cmake/help/v3.12/policy/CMP0074.html

Disclaimer: The description text was copied from @ax3l (https://github.com/ComputationalRadiationPhysics/cupla/pull/99)