### PR TITLE
Cleaning & C++14 Migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 project(mallocMC)
 cmake_minimum_required(VERSION 2.8.12.2)
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # helper for libs and packages
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/"
     "$ENV{CUDA_ROOT}" "$ENV{BOOST_ROOT}")
@@ -56,7 +59,7 @@ set(LIBS ${LIBS} ${Boost_LIBRARIES})
 # nvcc + boost 1.55 work around
 if(Boost_VERSION EQUAL 105500)
   set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} \"-DBOOST_NOINLINE=__attribute__((noinline))\" ")
-endif(Boost_VERSION EQUAL 105500)
+endif()
 
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,9 @@ endif()
 ###############################################################################
 # CUDA
 ###############################################################################
-find_package(CUDA REQUIRED)
+find_package(CUDA 9.0 REQUIRED)
 if(NOT DEFINED COMPUTE_CAPABILITY)
-    if(CUDA_VERSION VERSION_LESS 9.0)
-        set(COMPUTE_CAPABILITY "20")
-    else()
-        set(COMPUTE_CAPABILITY "30")
-    endif()
+    set(COMPUTE_CAPABILITY "30")
 endif()
 set(CUDA_NVCC_FLAGS "-arch=sm_${COMPUTE_CAPABILITY};-use_fast_math;")
 set(CUDA_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,19 +49,6 @@ if(NOT ${CUDA_OPTIMIZATION_TYPE} STREQUAL  "unset")
 endif()
 
 
-###############################################################################
-# Boost
-###############################################################################
-find_package(Boost 1.48.0 REQUIRED)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${Boost_LIBRARIES})
-
-# nvcc + boost 1.55 work around
-if(Boost_VERSION EQUAL 105500)
-  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} \"-DBOOST_NOINLINE=__attribute__((noinline))\" ")
-endif()
-
-
 ################################################################################
 # Warnings
 ################################################################################
@@ -117,8 +104,3 @@ cuda_add_executable(mallocMC_Example03
 cuda_add_executable(VerifyHeap
                     EXCLUDE_FROM_ALL
                     tests/verify_heap.cu )
-
-target_link_libraries(mallocMC_Example01 ${LIBS})
-target_link_libraries(mallocMC_Example02 ${LIBS})
-target_link_libraries(mallocMC_Example03 ${LIBS})
-target_link_libraries(VerifyHeap ${LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,12 @@
-project(mallocMC)
-cmake_minimum_required(VERSION 2.8.12.2)
+project(mallocMC LANGUAGES CUDA CXX)
+cmake_minimum_required(VERSION 3.8)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # helper for libs and packages
+set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/"
     "$ENV{CUDA_ROOT}" "$ENV{BOOST_ROOT}")
 
@@ -17,54 +19,38 @@ set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/"
 ################################################################################
 
 if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
+  cmake_policy(SET CMP0074 NEW)
 endif()
 
 
 ###############################################################################
 # CUDA
 ###############################################################################
-find_package(CUDA 9.0 REQUIRED)
 if(NOT DEFINED COMPUTE_CAPABILITY)
-    set(COMPUTE_CAPABILITY "30")
+  set(COMPUTE_CAPABILITY "30")
 endif()
-set(CUDA_NVCC_FLAGS "-arch=sm_${COMPUTE_CAPABILITY};-use_fast_math;")
-set(CUDA_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CUDA_INCLUDE_DIRS})
-cuda_include_directories(${CUDA_INCLUDE_DIRS})
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch=sm_${COMPUTE_CAPABILITY} -use_fast_math")
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 OPTION(CUDA_OUTPUT_INTERMEDIATE_CODE "Output ptx code" OFF)
 if(CUDA_OUTPUT_INTERMEDIATE_CODE)
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xptxas;-v;--keep")
-endif(CUDA_OUTPUT_INTERMEDIATE_CODE)
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xptxas -v --keep")
+endif()
 
 SET(CUDA_OPTIMIZATION_TYPE "unset" CACHE STRING "CUDA Optimization")
 set_property(CACHE CUDA_OPTIMIZATION_TYPE PROPERTY STRINGS "unset;-G0;-O0;-O1;-O2;-O3")
-if(NOT ${CUDA_OPTIMIZATION_TYPE} STREQUAL  "unset")
-  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};${CUDA_OPTIMIZATION_TYPE}")
+if(NOT ${CUDA_OPTIMIZATION_TYPE} STREQUAL "unset")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${CUDA_OPTIMIZATION_TYPE}")
 endif()
 
 
 ################################################################################
 # Warnings
 ################################################################################
-# GNU
 if(CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
-  # new warning in gcc 4.8 (flag ignored in previous version)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
-# ICC
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wshadow -Wno-unknown-pragmas -Wextra -Wno-unused-parameter -Wno-unused-local-typedefs")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_VARIADIC_TEMPLATES")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_CXX11_VARIADIC_TEMPLATES")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_NO_FENV_H")
-# PGI
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wshadow")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minform=inform")
 endif()
@@ -80,7 +66,7 @@ INSTALL(
   DESTINATION include
   PATTERN ".git" EXCLUDE
   PATTERN "mallocMC_config.hpp" EXCLUDE
-  )
+)
 
 
 ###############################################################################
@@ -88,15 +74,7 @@ INSTALL(
 ###############################################################################
 add_custom_target(examples DEPENDS mallocMC_Example01 mallocMC_Example02 mallocMC_Example03 VerifyHeap)
 
-cuda_add_executable(mallocMC_Example01
-                    EXCLUDE_FROM_ALL
-                    examples/mallocMC_example01.cu )
-cuda_add_executable(mallocMC_Example02
-                    EXCLUDE_FROM_ALL
-                    examples/mallocMC_example02.cu )
-cuda_add_executable(mallocMC_Example03
-                    EXCLUDE_FROM_ALL
-                    examples/mallocMC_example03.cu )
-cuda_add_executable(VerifyHeap
-                    EXCLUDE_FROM_ALL
-                    tests/verify_heap.cu )
+add_executable(mallocMC_Example01 EXCLUDE_FROM_ALL examples/mallocMC_example01.cu)
+add_executable(mallocMC_Example02 EXCLUDE_FROM_ALL examples/mallocMC_example02.cu)
+add_executable(mallocMC_Example03 EXCLUDE_FROM_ALL examples/mallocMC_example03.cu)
+add_executable(VerifyHeap EXCLUDE_FROM_ALL tests/verify_heap.cu)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 project(mallocMC LANGUAGES CUDA CXX)
 cmake_minimum_required(VERSION 3.8)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # helper for libs and packages
-set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD 11)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/"
     "$ENV{CUDA_ROOT}" "$ENV{BOOST_ROOT}")

--- a/Usage.md
+++ b/Usage.md
@@ -19,15 +19,15 @@ Currently, there are the following policy classes available:
 
 |Policy                 | Policy Classes (implementations) | description |
 |-------                |----------------------------------| ----------- |
-|**CreationPolicy**     | Scatter`<conf1,conf2>`           | A scattered allocation to tradeoff fragmentation for allocation time, as proposed in [ScatterAlloc](http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=6339604). `conf1` configures the heap layout, `conf2` determines the hashing parameters|
+|**CreationPolicy**     | Scatter`<conf1,conf2>`         | A scattered allocation to tradeoff fragmentation for allocation time, as proposed in [ScatterAlloc](http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=6339604). `conf1` configures the heap layout, `conf2` determines the hashing parameters|
 |                       | OldMalloc                        | device-side malloc/new and free/delete syscalls as implemented on NVidia CUDA graphics cards with compute capability sm_20 and higher |
-|**DistributionPolicy** | XMallocSIMD`<conf>`              | SIMD optimization for warp-wide allocation on NVIDIA CUDA accelerators, as proposed by [XMalloc](http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=5577907). `conf` is used to determine the pagesize. If used in combination with *Scatter*, the pagesizes must match |
+|**DistributionPolicy** | XMallocSIMD`<conf>`             | SIMD optimization for warp-wide allocation on NVIDIA CUDA accelerators, as proposed by [XMalloc](http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=5577907). `conf` is used to determine the pagesize. If used in combination with *Scatter*, the pagesizes must match |
 |                       | Noop                             | no workload distribution at all |
-|**OOMPolicy**          | ReturnNull                       | pointers will be *NULL*, if the request could not be fulfilled |
+|**OOMPolicy**          | ReturnNull                       | pointers will be *nullptr*, if the request could not be fulfilled |
 |                       | ~~BadAllocException~~            | will throw a `std::bad_alloc` exception. The accelerator has to support exceptions |
 |**ReservePoolPolicy**  | SimpleCudaMalloc                 | allocate a fixed heap with `CudaMalloc` |
 |                       | CudaSetLimits                    | call to `CudaSetLimits` to increase the available Heap (e.g. when using *OldMalloc*) |
-|**AlignmentPolicy**    | Shrink`<conf>`                   | shrinks the pool so that the starting pointer is well aligned, applies padding to requested memory chunks. `conf` is used to determine the alignment|
+|**AlignmentPolicy**    | Shrink`<conf>`                  | shrinks the pool so that the starting pointer is well aligned, applies padding to requested memory chunks. `conf` is used to determine the alignment|
 |                       | Noop                             | no alignment at all |
 
 The user has to choose one of each policy that will form a useful allocator
@@ -45,7 +45,7 @@ to the policy class:
 ```c++
 // configure the AlignmentPolicy "Shrink"
 struct ShrinkConfig : mallocMC::AlignmentPolicies::Shrink<>::Properties {
-  typedef boost::mpl::int_<16> dataAlignment;
+  using dataAlignment = boost::mpl::int_<16>;
 };
 ```
 
@@ -57,29 +57,29 @@ parameters to create the desired allocator type:
 ```c++
 using namespace mallocMC;
 
-typedef mallocMC::Allocator<
+using Allocator1 = mallocMC::Allocator<
   CreationPolicy::OldMalloc,
   DistributionPolicy::Noop,
   OOMPolicy::ReturnNull,
   ReservePoolPolicy::CudaSetLimits,
   AlignmentPolicy::Noop
-> Allocator1;
+>;
 ```
 
 `Allocator1` will resemble the behaviour of classical device-side allocation known
 from NVIDIA CUDA since compute capability sm_20. To get a more novel allocator, one
-could create the following typedef instead:
+could create the following alias instead:
 
 ```c++
 using namespace mallocMC;
 
-typedef mallocMC::Allocator<
+using ScatterAllocator = mallocMC::Allocator<
   CreationPolicies::Scatter<>,
   DistributionPolicies::XMallocSIMD<>,
   OOMPolicies::ReturnNull,
   ReservePoolPolicies::SimpleCudaMalloc,
   AlignmentPolicies::Shrink<ShrinkConfig>
-> ScatterAllocator;
+>;
 ```
 
 Notice, how the policy classes `Scatter` and `XMallocSIMD` are instantiated without
@@ -122,13 +122,13 @@ A simplistic example would look like this:
 
 namespace mallocMC = MC;
 
-typedef MC::Allocator<
+using ScatterAllocator = MC::Allocator<
   MC::CreationPolicies::Scatter<>,
   MC::DistributionPolicies::XMallocSIMD<>,
   MC::OOMPolicies::ReturnNull,
   MC::ReservePoolPolicies::SimpleCudaMalloc,
   MC::AlignmentPolicies::Shrink<ShrinkConfig>
-  > ScatterAllocator;
+>;
 
 __global__ exampleKernel(ScatterAllocator::AllocatorHandle sah)
 {

--- a/Usage.md
+++ b/Usage.md
@@ -45,7 +45,7 @@ to the policy class:
 ```c++
 // configure the AlignmentPolicy "Shrink"
 struct ShrinkConfig : mallocMC::AlignmentPolicies::Shrink<>::Properties {
-  using dataAlignment = boost::mpl::int_<16>;
+  static constexpr auto dataAlignment = 16;
 };
 ```
 

--- a/examples/mallocMC_example01_config.cu
+++ b/examples/mallocMC_example01_config.cu
@@ -40,7 +40,7 @@
 
 // configurate the CreationPolicy "Scatter" to modify the default behaviour
 struct ScatterHeapConfig : mallocMC::CreationPolicies::Scatter<>::HeapProperties{
-  static constexpr auto pagesize = 4096u;
+  static constexpr auto pagesize = 4096;
   static constexpr auto accessblocks = 8;
   static constexpr auto regionsize = 16;
   static constexpr auto wastefactor = 2;

--- a/examples/mallocMC_example01_config.cu
+++ b/examples/mallocMC_example01_config.cu
@@ -28,9 +28,6 @@
 
 #pragma once
 
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/bool.hpp>
-
 // basic files for mallocMC
 #include "src/include/mallocMC/mallocMC_hostclass.hpp"
 
@@ -40,41 +37,39 @@
 #include "src/include/mallocMC/OOMPolicies.hpp"
 #include "src/include/mallocMC/ReservePoolPolicies.hpp"
 #include "src/include/mallocMC/AlignmentPolicies.hpp"
-    
-
 
 // configurate the CreationPolicy "Scatter" to modify the default behaviour
 struct ScatterHeapConfig : mallocMC::CreationPolicies::Scatter<>::HeapProperties{
-    typedef boost::mpl::int_<4096>  pagesize;
-    typedef boost::mpl::int_<8>     accessblocks;
-    typedef boost::mpl::int_<16>    regionsize;
-    typedef boost::mpl::int_<2>     wastefactor;
-    typedef boost::mpl::bool_<false> resetfreedpages;
+  static constexpr auto pagesize = 4096u;
+  static constexpr auto accessblocks = 8;
+  static constexpr auto regionsize = 16;
+  static constexpr auto wastefactor = 2;
+  static constexpr auto resetfreedpages = false;
 };
 
 struct ScatterHashConfig : mallocMC::CreationPolicies::Scatter<>::HashingProperties{
-    typedef boost::mpl::int_<38183> hashingK;
-    typedef boost::mpl::int_<17497> hashingDistMP;
-    typedef boost::mpl::int_<1>     hashingDistWP;
-    typedef boost::mpl::int_<1>     hashingDistWPRel;
+  static constexpr auto hashingK = 38183;
+  static constexpr auto hashingDistMP = 17497;
+  static constexpr auto hashingDistWP = 1;
+  static constexpr auto hashingDistWPRel = 1;
 };
 
 // configure the DistributionPolicy "XMallocSIMD"
 struct XMallocConfig : mallocMC::DistributionPolicies::XMallocSIMD<>::Properties {
-  typedef ScatterHeapConfig::pagesize pagesize;
+  static constexpr auto pagesize = ScatterHeapConfig::pagesize;
 };
 
 // configure the AlignmentPolicy "Shrink"
 struct ShrinkConfig : mallocMC::AlignmentPolicies::Shrink<>::Properties {
-  typedef boost::mpl::int_<16> dataAlignment;
+  static constexpr auto dataAlignment = 16;
 };
 
 // Define a new allocator and call it ScatterAllocator
 // which resembles the behaviour of ScatterAlloc
-typedef mallocMC::Allocator< 
+using ScatterAllocator = mallocMC::Allocator<
   mallocMC::CreationPolicies::Scatter<ScatterHeapConfig, ScatterHashConfig>,
   mallocMC::DistributionPolicies::XMallocSIMD<XMallocConfig>,
   mallocMC::OOMPolicies::ReturnNull,
   mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
   mallocMC::AlignmentPolicies::Shrink<ShrinkConfig>
-  > ScatterAllocator;
+>;

--- a/examples/mallocMC_example02.cu
+++ b/examples/mallocMC_example02.cu
@@ -52,7 +52,7 @@
 
 // configurate the CreationPolicy "Scatter"
 struct ScatterConfig{
-  static constexpr auto pagesize = 4096u;
+  static constexpr auto pagesize = 4096;
   static constexpr auto accessblocks = 8;
   static constexpr auto regionsize = 16;
   static constexpr auto wastefactor = 2;

--- a/examples/mallocMC_example02.cu
+++ b/examples/mallocMC_example02.cu
@@ -32,8 +32,6 @@
 #include <numeric>
 
 #include <cuda.h>
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/bool.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // includes for mallocMC
@@ -54,39 +52,39 @@
 
 // configurate the CreationPolicy "Scatter"
 struct ScatterConfig{
-    typedef boost::mpl::int_<4096>  pagesize;
-    typedef boost::mpl::int_<8>     accessblocks;
-    typedef boost::mpl::int_<16>    regionsize;
-    typedef boost::mpl::int_<2>     wastefactor;
-    typedef boost::mpl::bool_<false> resetfreedpages;
+  static constexpr auto pagesize = 4096u;
+  static constexpr auto accessblocks = 8;
+  static constexpr auto regionsize = 16;
+  static constexpr auto wastefactor = 2;
+  static constexpr auto resetfreedpages = false;
 };
 
 struct ScatterHashParams{
-    typedef boost::mpl::int_<38183> hashingK;
-    typedef boost::mpl::int_<17497> hashingDistMP;
-    typedef boost::mpl::int_<1>     hashingDistWP;
-    typedef boost::mpl::int_<1>     hashingDistWPRel;
+  static constexpr auto hashingK = 38183;
+  static constexpr auto hashingDistMP = 17497;
+  static constexpr auto hashingDistWP = 1;
+  static constexpr auto hashingDistWPRel = 1;
 };
 
 // configure the DistributionPolicy "XMallocSIMD"
 struct DistributionConfig{
-  typedef ScatterConfig::pagesize pagesize;
+  static constexpr auto pagesize = ScatterConfig::pagesize;
 };
 
 // configure the AlignmentPolicy "Shrink"
 struct AlignmentConfig{
-  typedef boost::mpl::int_<16> dataAlignment;
+  static constexpr auto dataAlignment = 16;
 };
 
 // Define a new mMCator and call it ScatterAllocator
 // which resembles the behaviour of ScatterAlloc
-typedef mallocMC::Allocator<
+using ScatterAllocator = mallocMC::Allocator<
   mallocMC::CreationPolicies::Scatter<ScatterConfig,ScatterHashParams>,
   mallocMC::DistributionPolicies::XMallocSIMD<DistributionConfig>,
   mallocMC::OOMPolicies::ReturnNull,
   mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
   mallocMC::AlignmentPolicies::Shrink<AlignmentConfig>
-  > ScatterAllocator;
+>;
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/examples/mallocMC_example03.cu
+++ b/examples/mallocMC_example03.cu
@@ -33,8 +33,6 @@
 #include <stdio.h>
 
 #include <cuda.h>
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/bool.hpp>
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -55,24 +53,24 @@
 
 // configurate the CreationPolicy "Scatter"
 struct ScatterConfig{
-    typedef boost::mpl::int_<4096>  pagesize;
-    typedef boost::mpl::int_<8>     accessblocks;
-    typedef boost::mpl::int_<16>    regionsize;
-    typedef boost::mpl::int_<2>     wastefactor;
-    typedef boost::mpl::bool_<false> resetfreedpages;
+    static constexpr auto pagesize = 4096;
+    static constexpr auto accessblocks = 8;
+    static constexpr auto regionsize = 16;
+    static constexpr auto wastefactor = 2;
+    static constexpr auto resetfreedpages = false;
 };
 
 struct ScatterHashParams{
-    typedef boost::mpl::int_<38183> hashingK;
-    typedef boost::mpl::int_<17497> hashingDistMP;
-    typedef boost::mpl::int_<1>     hashingDistWP;
-    typedef boost::mpl::int_<1>     hashingDistWPRel;
+    static constexpr auto hashingK = 38183;
+    static constexpr auto hashingDistMP = 17497;
+    static constexpr auto hashingDistWP = 1;
+    static constexpr auto hashingDistWPRel = 1;
 };
 
 
 // configure the AlignmentPolicy "Shrink"
 struct AlignmentConfig{
-    typedef boost::mpl::int_<16> dataAlignment;
+    static constexpr auto dataAlignment = 16;
 };
 
 // Define a new mMCator and call it ScatterAllocator

--- a/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
@@ -27,8 +27,9 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <string>
+#include <tuple>
 
 #include "Noop.hpp"
 #include "../mallocMC_prefixes.hpp"
@@ -37,12 +38,12 @@ namespace mallocMC{
 namespace AlignmentPolicies{
 
   class Noop{
-    typedef boost::uint32_t uint32;
+    using uint32 = std::uint32_t;
 
     public:
 
-    static boost::tuple<void*,size_t> alignPool(void* memory, size_t memsize){
-      return boost::make_tuple(memory,memsize);
+    static std::tuple<void*,size_t> alignPool(void* memory, size_t memsize){
+      return std::make_tuple(memory, memsize);
     }
 
     MAMC_HOST MAMC_ACCELERATOR
@@ -53,7 +54,6 @@ namespace AlignmentPolicies{
     static std::string classname(){
       return "Noop";
     }
-
   };
 
 } //namespace AlignmentPolicies

--- a/src/include/mallocMC/alignmentPolicies/Shrink.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink.hpp
@@ -31,14 +31,12 @@
 
 #pragma once
 
-#include <boost/mpl/int.hpp>
-
 namespace mallocMC{
 namespace AlignmentPolicies{
 
 namespace ShrinkConfig{
   struct DefaultShrinkConfig{
-    typedef boost::mpl::int_<16> dataAlignment;
+    static constexpr auto dataAlignment = 16;
   };
 }
 

--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -31,12 +31,10 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
-#include <boost/static_assert.hpp>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <sstream>
-#include <boost/tuple/tuple.hpp>
 
 #include "Shrink.hpp"
 #include "../mallocMC_prefixes.hpp"
@@ -57,7 +55,7 @@ namespace Shrink2NS{
     typedef T_Config Properties;
 
     private:
-    typedef boost::uint32_t uint32;
+    using uint32 = std::uint32_t;
     typedef Shrink2NS::__PointerEquivalent<sizeof(char*)>::type PointerEquivalent;
 
 /** Allow for a hierarchical validation of parameters:
@@ -72,16 +70,16 @@ namespace Shrink2NS{
 #ifndef MALLOCMC_AP_SHRINK_DATAALIGNMENT
 #define MALLOCMC_AP_SHRINK_DATAALIGNMENT Properties::dataAlignment::value
 #endif
-    BOOST_STATIC_CONSTEXPR uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
+    static constexpr uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
 
     // \TODO: The static_cast can be removed once the minimal dependencies of
     //        this project is are at least CUDA 7.0 and gcc 4.8.2
-    BOOST_STATIC_ASSERT(static_cast<uint32>(dataAlignment) > 0);
+    static_assert(static_cast<uint32>(dataAlignment) > 0, "");
     //dataAlignment must also be a power of 2!
-    BOOST_STATIC_ASSERT(dataAlignment && !(dataAlignment & (dataAlignment-1)) ); 
+    static_assert(dataAlignment && !(dataAlignment & (dataAlignment-1)), "");
 
     public:
-    static boost::tuple<void*,size_t> alignPool(void* memory, size_t memsize){
+    static std::tuple<void*,size_t> alignPool(void* memory, size_t memsize){
       PointerEquivalent alignmentstatus = ((PointerEquivalent)memory) & (dataAlignment -1);
       if(alignmentstatus != 0)
       {
@@ -101,7 +99,7 @@ namespace Shrink2NS{
         std::cout << "void *memory     " << memory              << std::endl;
       }
 
-      return boost::make_tuple(memory,memsize);
+      return std::make_tuple(memory,memsize);
     }
 
     MAMC_HOST

--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -73,7 +73,7 @@ namespace Shrink2NS{
     static constexpr uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
 
     //dataAlignment must be a power of 2!
-    static_assert(dataAlignment && !(dataAlignment & (dataAlignment-1)), "");
+    static_assert(dataAlignment && !(dataAlignment & (dataAlignment-1)), "dataAlignment must also be a power of 2");
 
     public:
     static std::tuple<void*,size_t> alignPool(void* memory, size_t memsize){

--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -68,13 +68,13 @@ namespace Shrink2NS{
  * default-struct < template-struct < command-line parameter
  */
 #ifndef MALLOCMC_AP_SHRINK_DATAALIGNMENT
-#define MALLOCMC_AP_SHRINK_DATAALIGNMENT Properties::dataAlignment::value
+#define MALLOCMC_AP_SHRINK_DATAALIGNMENT (Properties::dataAlignment)
 #endif
     static constexpr uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
 
     // \TODO: The static_cast can be removed once the minimal dependencies of
     //        this project is are at least CUDA 7.0 and gcc 4.8.2
-    static_assert(static_cast<uint32>(dataAlignment) > 0, "");
+    static_assert(dataAlignment > 0, "");
     //dataAlignment must also be a power of 2!
     static_assert(dataAlignment && !(dataAlignment & (dataAlignment-1)), "");
 

--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -72,10 +72,7 @@ namespace Shrink2NS{
 #endif
     static constexpr uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
 
-    // \TODO: The static_cast can be removed once the minimal dependencies of
-    //        this project is are at least CUDA 7.0 and gcc 4.8.2
-    static_assert(dataAlignment > 0, "");
-    //dataAlignment must also be a power of 2!
+    //dataAlignment must be a power of 2!
     static_assert(dataAlignment && !(dataAlignment & (dataAlignment-1)), "");
 
     public:

--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -34,14 +34,12 @@
 #include "mallocMC_traits.hpp"
 #include "mallocMC_allocator_handle.hpp"
 
-#include <boost/cstdint.hpp>
-#include <boost/tuple/tuple.hpp>
-#include <boost/static_assert.hpp>
+#include <cstdint>
+#include <tuple>
 #include <sstream>
 #include <vector>
 
 namespace mallocMC{
-
 namespace detail{
 
     template<
@@ -73,9 +71,7 @@ namespace detail{
             return T_Allocator::CreationPolicy::getAvailableSlotsHost(slotSize, alloc.getAllocatorHandle().devAllocator);
         }
     };
-
 }
-
 
     struct HeapInfo
     {
@@ -113,7 +109,7 @@ namespace detail{
             T_AlignmentPolicy
         >
     {
-        typedef boost::uint32_t uint32;
+        using uint32 = std::uint32_t;
 
     public:
         typedef T_CreationPolicy CreationPolicy;
@@ -145,7 +141,7 @@ namespace detail{
         )
         {
             void* pool = ReservePoolPolicy::setMemPool( size );
-            boost::tie(
+            std::tie(
                 pool,
                 size
             ) = AlignmentPolicy::alignPool(
@@ -178,9 +174,9 @@ namespace detail{
         {
             cudaFree( allocatorHandle.devAllocator );
             ReservePoolPolicy::resetMemPool( heapInfos.p );
-            allocatorHandle.devAllocator = NULL;
+            allocatorHandle.devAllocator = nullptr;
             heapInfos.size = 0;
-            heapInfos.p = NULL;
+            heapInfos.p = nullptr;
         }
 
         /* forbid to copy the allocator */
@@ -194,7 +190,7 @@ namespace detail{
         Allocator(
             size_t size = 8U * 1024U * 1024U
         ) :
-            allocatorHandle( NULL )
+            allocatorHandle( nullptr )
         {
             alloc( size );
         }

--- a/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
@@ -28,7 +28,6 @@
 #pragma once
 
 #include <cstdint>
-#include <boost/mpl/bool.hpp>
 
 #include "OldMalloc.hpp"
 
@@ -40,7 +39,7 @@ namespace CreationPolicies{
     using uint32 = std::uint32_t;
 
     public:
-    typedef boost::mpl::bool_<false> providesAvailableSlots;
+    static constexpr auto providesAvailableSlots = false;
 
     __device__ void* create(uint32 bytes) const
     {

--- a/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <boost/mpl/bool.hpp>
 
 #include "OldMalloc.hpp"
@@ -37,34 +37,33 @@ namespace CreationPolicies{
 
   class OldMalloc
   {
-    typedef boost::uint32_t uint32;
+    using uint32 = std::uint32_t;
 
     public:
     typedef boost::mpl::bool_<false> providesAvailableSlots;
 
-    __device__ void* create(uint32 bytes)
+    __device__ void* create(uint32 bytes) const
     {
       return ::malloc(static_cast<size_t>(bytes));
     }
 
-    __device__ void destroy(void* mem)
+    __device__ void destroy(void* mem) const
     {
-      free(mem);
+      ::free(mem);
     }
 
-    __device__ bool isOOM(void* p, size_t s){
-      return s && (p == NULL);
+    __device__ bool isOOM(void* p, size_t s) const {
+      return s && (p == nullptr);
     }
 
     template < typename T >
-    static void* initHeap(T* dAlloc, void*, size_t){
+    static void* initHeap(T* dAlloc, void*, size_t) {
       return dAlloc;
     }
 
-    static std::string classname(){
+    static std::string classname() {
       return "OldMalloc";
     }
-
   };
 
 } //namespace CreationPolicies

--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -33,25 +33,22 @@
 
 #pragma once
 
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/int.hpp>
-
 namespace mallocMC{
 namespace CreationPolicies{
 namespace ScatterConf{
   struct DefaultScatterConfig{
-    typedef boost::mpl::int_<4096>  pagesize;
-    typedef boost::mpl::int_<8>     accessblocks;
-    typedef boost::mpl::int_<16>    regionsize;
-    typedef boost::mpl::int_<2>     wastefactor;
-    typedef boost::mpl::bool_<false> resetfreedpages;
+    static constexpr auto pagesize = 4096;
+    static constexpr auto accessblocks = 8;
+    static constexpr auto regionsize = 16;
+    static constexpr auto wastefactor = 2;
+    static constexpr auto resetfreedpages = false;
   };
 
   struct DefaultScatterHashingParams{
-    typedef boost::mpl::int_<38183> hashingK;
-    typedef boost::mpl::int_<17497> hashingDistMP;
-    typedef boost::mpl::int_<1>     hashingDistWP;
-    typedef boost::mpl::int_<1>     hashingDistWPRel;
+    static constexpr auto hashingK = 38183;
+    static constexpr auto hashingDistMP = 17497;
+    static constexpr auto hashingDistWP = 1;
+    static constexpr auto hashingDistWPRel = 1;
   };  
 }
 

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -710,7 +710,7 @@ namespace ScatterKernelDetail{
         uint32 blocks =  gridDim.x*gridDim.y*gridDim.z;
         linid += linblockid*threads;
 
-        uint32 numregions = ((unsigned long long)memsize)/( ((unsigned long long)regionsize)*(sizeof(PTE)+pagesize)+sizeof(uint32)); // TODO(bgruber): why unsigned long long and not size_t?
+        uint32 numregions = ((unsigned long long)memsize)/( ((unsigned long long)regionsize)*(sizeof(PTE)+pagesize)+sizeof(uint32));
 
         uint32 numpages = numregions*regionsize;
         //pointer is copied (copy is called page)

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -179,7 +179,7 @@ namespace ScatterKernelDetail{
        * The page struct is used to access the data on the page more efficiently
        * and to clear the area on the page, which might hold bitsfields later one
        */
-      struct PAGE // TODO(bgruber): why is this in ALLCAPS?
+      struct Page
       {
         char data[pagesize];
 
@@ -202,7 +202,7 @@ namespace ScatterKernelDetail{
 
       volatile PTE* _ptes;
       volatile uint32* _regions;
-      PAGE* _page;
+      Page* _page;
       uint32 _numpages;
       size_t _memsize;
       uint32 _pagebasedMutex;
@@ -719,7 +719,7 @@ namespace ScatterKernelDetail{
 
         uint32 numpages = numregions*regionsize;
         //pointer is copied (copy is called page)
-        PAGE* page = (PAGE*)memory;
+        Page* page = (Page*)memory;
         //sec check for alignment
         //copy is checked
         //PointerEquivalent alignmentstatus = ((PointerEquivalent)page) & (16 -1);
@@ -733,14 +733,14 @@ namespace ScatterKernelDetail{
         //    printf("c void *memory     %p\n", page);
         //  }
         //  //copy is adjusted, potentially pointer to higher address now.
-        //  page =(PAGE*)(((PointerEquivalent)page) + 16 - alignmentstatus);
+        //  page =(Page*)(((PointerEquivalent)page) + 16 - alignmentstatus);
         //  if(linid == 0) printf("c Heap Warning: memory to use not 16 byte aligned...\n");
         //}
         PTE* ptes = (PTE*)(page + numpages);
         uint32* regions = (uint32*)(ptes + numpages);
         //sec check for mem size
         //this check refers to the original memory-pointer, which was not adjusted!
-        if( (void*)(regions + numregions) > (((char*)memory) + memsize) ) // TODO(bgruber): cast to void* is confusing and looks dangerous
+        if( (char*)(regions + numregions) > (((char*)memory) + memsize) )
         {
           --numregions;
           numpages = min(numregions*regionsize,numpages);

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -34,7 +34,7 @@
 #pragma once
 
 #include <cstdio>
-#include <boost/cstdint.hpp> /* uint32_t */
+#include <cstdint> /* uint32_t */
 #include <iostream>
 #include <string>
 #include <cassert>
@@ -74,7 +74,6 @@ namespace ScatterKernelDetail{
   template<class T_Config, class T_Hashing>
   class Scatter
   {
-
     public:
       typedef T_Config  HeapProperties;
       typedef T_Hashing HashingProperties;
@@ -82,7 +81,7 @@ namespace ScatterKernelDetail{
       typedef boost::mpl::bool_<true>  providesAvailableSlots;
 
     private:
-      typedef boost::uint32_t uint32;
+      using uint32 = std::uint32_t;
 
 
 /** Allow for a hierarchical validation of parameters:
@@ -97,66 +96,65 @@ namespace ScatterKernelDetail{
 #ifndef MALLOCMC_CP_SCATTER_PAGESIZE
 #define MALLOCMC_CP_SCATTER_PAGESIZE  static_cast<uint32>(HeapProperties::pagesize::value)
 #endif
-      BOOST_STATIC_CONSTEXPR uint32 pagesize      = MALLOCMC_CP_SCATTER_PAGESIZE;
+      static constexpr uint32 pagesize      = MALLOCMC_CP_SCATTER_PAGESIZE;
 
 #ifndef MALLOCMC_CP_SCATTER_ACCESSBLOCKS
 #define MALLOCMC_CP_SCATTER_ACCESSBLOCKS static_cast<uint32>(HeapProperties::accessblocks::value)
 #endif
-      BOOST_STATIC_CONSTEXPR uint32 accessblocks  = MALLOCMC_CP_SCATTER_ACCESSBLOCKS;
+      static constexpr uint32 accessblocks  = MALLOCMC_CP_SCATTER_ACCESSBLOCKS;
 
 #ifndef MALLOCMC_CP_SCATTER_REGIONSIZE
 #define MALLOCMC_CP_SCATTER_REGIONSIZE static_cast<uint32>(HeapProperties::regionsize::value)
 #endif
-      BOOST_STATIC_CONSTEXPR uint32 regionsize    = MALLOCMC_CP_SCATTER_REGIONSIZE;
+      static constexpr uint32 regionsize    = MALLOCMC_CP_SCATTER_REGIONSIZE;
 
 #ifndef MALLOCMC_CP_SCATTER_WASTEFACTOR
 #define MALLOCMC_CP_SCATTER_WASTEFACTOR static_cast<uint32>(HeapProperties::wastefactor::value)
 #endif
-      BOOST_STATIC_CONSTEXPR uint32 wastefactor   = MALLOCMC_CP_SCATTER_WASTEFACTOR;
+      static constexpr uint32 wastefactor   = MALLOCMC_CP_SCATTER_WASTEFACTOR;
 
 #ifndef MALLOCMC_CP_SCATTER_RESETFREEDPAGES
 #define MALLOCMC_CP_SCATTER_RESETFREEDPAGES static_cast<bool>(HeapProperties::resetfreedpages::value)
 #endif
-      BOOST_STATIC_CONSTEXPR bool resetfreedpages = MALLOCMC_CP_SCATTER_RESETFREEDPAGES;
-
+      static constexpr bool resetfreedpages = MALLOCMC_CP_SCATTER_RESETFREEDPAGES;
 
     public:
-      BOOST_STATIC_CONSTEXPR uint32 _pagesize       = pagesize;
-      BOOST_STATIC_CONSTEXPR uint32 _accessblocks   = accessblocks;
-      BOOST_STATIC_CONSTEXPR uint32 _regionsize     = regionsize;
-      BOOST_STATIC_CONSTEXPR uint32 _wastefactor    = wastefactor;
-      BOOST_STATIC_CONSTEXPR bool _resetfreedpages  = resetfreedpages;
+      static constexpr uint32 _pagesize       = pagesize;
+      static constexpr uint32 _accessblocks   = accessblocks;
+      static constexpr uint32 _regionsize     = regionsize;
+      static constexpr uint32 _wastefactor    = wastefactor;
+      static constexpr bool _resetfreedpages  = resetfreedpages;
 
     private:
 #if _DEBUG || ANALYSEHEAP
     public:
 #endif
-      //BOOST_STATIC_CONSTEXPR uint32 minChunkSize0 = pagesize/(32*32);
-      BOOST_STATIC_CONSTEXPR uint32 minChunkSize1 = 0x10;
-      BOOST_STATIC_CONSTEXPR uint32 HierarchyThreshold =  (pagesize - 2*sizeof(uint32))/33;
-      BOOST_STATIC_CONSTEXPR uint32 minSegmentSize = 32*minChunkSize1 + sizeof(uint32);
-      BOOST_STATIC_CONSTEXPR uint32 tmp_maxOPM = minChunkSize1 > HierarchyThreshold ? 0 : (pagesize + (minSegmentSize-1)) / minSegmentSize;
-      BOOST_STATIC_CONSTEXPR uint32 maxOnPageMasks = 32 > tmp_maxOPM ? tmp_maxOPM : 32;
+      //static constexpr uint32 minChunkSize0 = pagesize/(32*32);
+      static constexpr uint32 minChunkSize1 = 0x10;
+      static constexpr uint32 HierarchyThreshold =  (pagesize - 2*sizeof(uint32))/33;
+      static constexpr uint32 minSegmentSize = 32*minChunkSize1 + sizeof(uint32);
+      static constexpr uint32 tmp_maxOPM = minChunkSize1 > HierarchyThreshold ? 0 : (pagesize + (minSegmentSize-1)) / minSegmentSize;
+      static constexpr uint32 maxOnPageMasks = 32 > tmp_maxOPM ? tmp_maxOPM : 32;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGK
 #define MALLOCMC_CP_SCATTER_HASHINGK    static_cast<uint32>(HashingProperties::hashingK::value)
 #endif
-     BOOST_STATIC_CONSTEXPR uint32 hashingK       = MALLOCMC_CP_SCATTER_HASHINGK;
+     static constexpr uint32 hashingK       = MALLOCMC_CP_SCATTER_HASHINGK;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTMP
 #define MALLOCMC_CP_SCATTER_HASHINGDISTMP static_cast<uint32>(HashingProperties::hashingDistMP::value)
 #endif
-     BOOST_STATIC_CONSTEXPR uint32 hashingDistMP  = MALLOCMC_CP_SCATTER_HASHINGDISTMP;
+     static constexpr uint32 hashingDistMP  = MALLOCMC_CP_SCATTER_HASHINGDISTMP;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTWP
 #define MALLOCMC_CP_SCATTER_HASHINGDISTWP static_cast<uint32>(HashingProperties::hashingDistWP::value)
 #endif
-     BOOST_STATIC_CONSTEXPR uint32 hashingDistWP  = MALLOCMC_CP_SCATTER_HASHINGDISTWP;
+     static constexpr uint32 hashingDistWP  = MALLOCMC_CP_SCATTER_HASHINGDISTWP;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTWPREL
 #define MALLOCMC_CP_SCATTER_HASHINGDISTWPREL static_cast<uint32>(HashingProperties::hashingDistWPRel::value)
 #endif
-     BOOST_STATIC_CONSTEXPR uint32 hashingDistWPRel = MALLOCMC_CP_SCATTER_HASHINGDISTWPREL;
+     static constexpr uint32 hashingDistWPRel = MALLOCMC_CP_SCATTER_HASHINGDISTWPREL;
 
 
       /**
@@ -182,7 +180,7 @@ namespace ScatterKernelDetail{
        * The page struct is used to access the data on the page more efficiently
        * and to clear the area on the page, which might hold bitsfields later one
        */
-      struct PAGE
+      struct PAGE // TODO(bgruber): why is this in ALLCAPS?
       {
         char data[pagesize];
 
@@ -217,7 +215,7 @@ namespace ScatterKernelDetail{
        * randInit should create an random offset which can be used
        * as the initial position in a bitfield
        */
-      __device__ inline uint32 randInit()
+      static __device__ inline uint32 randInit()
       {
         //start with the laneid offset
         return laneid();
@@ -233,12 +231,12 @@ namespace ScatterKernelDetail{
        * @param spots number of bits that can be used
        * @return next free spot in the bitfield
        */
-      __device__ inline uint32 nextspot(uint32 bitfield, uint32 spot, uint32 spots)
+      static __device__ inline uint32 nextspot(uint32 bitfield, uint32 spot, uint32 spots)
       {
         //wrap around the bitfields from the current spot to the left
         bitfield = ((bitfield >> (spot + 1)) | (bitfield << (spots - (spot + 1))))&((1<<spots)-1);
         //compute the step from the current spot in the bitfield
-        uint32 step = __ffs(~bitfield);
+        const uint32 step = __ffs(~bitfield);
         //and return the new spot
         return (spot + step) % spots;
       }
@@ -251,7 +249,7 @@ namespace ScatterKernelDetail{
        * @return pointer to the first address inside the page that holds metadata bitfields.
        */
       __device__ inline uint32* onPageMasksPosition(uint32 page, uint32 nMasks){
-        return (uint32*)(_page[page].data + pagesize - (int)sizeof(uint32)*nMasks);
+        return (uint32*)(_page[page].data + pagesize - (int)sizeof(uint32) * nMasks);
       }
 
       /**
@@ -260,14 +258,14 @@ namespace ScatterKernelDetail{
        * @param spots overall number of spots the bitfield is responsible for
        * @return if there is a free spot it returns the spot'S offset, otherwise -1
        */
-      __device__ inline int usespot(uint32 *bitfield, uint32 spots)
+      static __device__ inline int usespot(uint32 *bitfield, uint32 spots)
       {
         //get first spot
         uint32 spot = randInit() % spots;
         for(;;)
         {
-          uint32 mask = 1 << spot;
-          uint32 old = atomicOr(bitfield, mask);
+          const uint32 mask = 1 << spot;
+          const uint32 old = atomicOr(bitfield, mask);
           if( (old & mask) == 0)
             return spot;
           // note: __popc(old) == spots should be sufficient,
@@ -289,10 +287,10 @@ namespace ScatterKernelDetail{
        * @param chunksize the chosen allocation size within the page
        * @return the number of additional chunks that will not fit in one of the fullsegments. For any correct input, this number is smaller than 32
        */
-      __device__ inline uint32 calcAdditionalChunks(uint32 fullsegments, uint32 segmentsize, uint32 chunksize){
-        if(fullsegments != 32){
-          return max(0,(int)pagesize - (int)fullsegments*segmentsize - (int)sizeof(uint32))/chunksize;
-        }else
+      static __device__ inline uint32 calcAdditionalChunks(uint32 fullsegments, uint32 segmentsize, uint32 chunksize){
+        if(fullsegments != 32)
+          return max(0, (int)pagesize - (int)fullsegments*segmentsize - (int)sizeof(uint32)) / chunksize;
+        else
           return 0;
       }
 
@@ -307,20 +305,19 @@ namespace ScatterKernelDetail{
        */
       __device__ inline void* addChunkHierarchy(uint32 chunksize, uint32 fullsegments, uint32 additional_chunks, uint32 page)
       {
-        uint32 segments = fullsegments + (additional_chunks > 0 ? 1 : 0);
+        const uint32 segments = fullsegments + (additional_chunks > 0 ? 1 : 0);
         uint32 spot = randInit() % segments;
-        uint32 mask = _ptes[page].bitmask;
+        const uint32 mask = _ptes[page].bitmask;
         if((mask & (1 << spot)) != 0)
           spot = nextspot(mask, spot, segments);
-        uint32 tries = segments - __popc(mask);
+        const uint32 tries = segments - __popc(mask);
         uint32* onpagemasks = onPageMasksPosition(page,segments);
         for(uint32 i = 0; i < tries; ++i)
         {
-          int hspot = usespot(onpagemasks + spot, spot < fullsegments ? 32 : additional_chunks);
+          const int hspot = usespot(&onpagemasks[spot], spot < fullsegments ? 32 : additional_chunks);
           if(hspot != -1)
             return _page[page].data + (32*spot + hspot)*chunksize;
-          else
-            atomicOr((uint32*)&_ptes[page].bitmask, 1 << spot);
+          atomicOr((uint32*)&_ptes[page].bitmask, 1 << spot);
           spot = nextspot(mask, spot, segments);
         }
         return 0;
@@ -335,7 +332,7 @@ namespace ScatterKernelDetail{
        */
       __device__ inline void* addChunkNoHierarchy(uint32 chunksize, uint32 page, uint32 spots)
       {
-        int spot = usespot((uint32*)&_ptes[page].bitmask, spots);
+        const int spot = usespot((uint32*)&_ptes[page].bitmask, spots);
         if(spot == -1)
           return 0; //that should be impossible :)
         return _page[page].data + spot*chunksize;
@@ -349,33 +346,32 @@ namespace ScatterKernelDetail{
        */
       __device__ inline void* tryUsePage(uint32 page, uint32 chunksize)
       {
-
-        void* chunk_ptr = NULL;
+        void* chunk_ptr = nullptr;
 
         //increse the fill level
-        uint32 filllevel = atomicAdd((uint32*)&(_ptes[page].count), 1);
+        const uint32 filllevel = atomicAdd((uint32*)&(_ptes[page].count), 1);
         //recheck chunck size (it could be that the page got freed in the meanwhile...)
         if(!resetfreedpages || _ptes[page].chunksize == chunksize)
         {
           if(chunksize <= HierarchyThreshold)
           {
             //more chunks than can be covered by the pte's single bitfield can be used
-            uint32 segmentsize = chunksize*32 + sizeof(uint32);
-            uint32 fullsegments = min(32,pagesize / segmentsize);
-            uint32 additional_chunks = calcAdditionalChunks(fullsegments, segmentsize, chunksize);
+            const uint32 segmentsize = chunksize*32 + sizeof(uint32);
+            const uint32 fullsegments = min(32,pagesize / segmentsize);
+            const uint32 additional_chunks = calcAdditionalChunks(fullsegments, segmentsize, chunksize);
             if(filllevel < fullsegments * 32 + additional_chunks)
               chunk_ptr = addChunkHierarchy(chunksize, fullsegments, additional_chunks, page);
           }
           else
           {
-            uint32 chunksinpage = min(pagesize / chunksize, 32);
+            const uint32 chunksinpage = min(pagesize / chunksize, 32);
             if(filllevel < chunksinpage)
               chunk_ptr = addChunkNoHierarchy(chunksize, page, chunksinpage);
           }
         }
 
         //this one is full/not useable
-        if(chunk_ptr == NULL)
+        if(chunk_ptr == nullptr)
           atomicSub((uint32*)&(_ptes[page].count), 1);
 
         return chunk_ptr;
@@ -389,10 +385,10 @@ namespace ScatterKernelDetail{
        */
       __device__ void* allocChunked(uint32 bytes)
       {
-        uint32 pagesperblock = _numpages/accessblocks;
-        uint32 reloff = warpSize*bytes / pagesize;
-        uint32 startpage = (bytes*hashingK + hashingDistMP*smid() + (hashingDistWP+hashingDistWPRel*reloff)*warpid() ) % pagesperblock;
-        uint32 maxchunksize = min(pagesize,wastefactor*bytes);
+        const uint32 pagesperblock = _numpages/accessblocks;
+        const uint32 reloff = warpSize*bytes / pagesize;
+        const uint32 startpage = (bytes*hashingK + hashingDistMP*smid() + (hashingDistWP+hashingDistWPRel*reloff)*warpid() ) % pagesperblock;
+        const uint32 maxchunksize = min(pagesize,wastefactor*bytes);
         uint32 startblock = _firstfreeblock;
         uint32 ptetry = startpage + startblock*pagesperblock;
         uint32 checklevel = regionsize*3/4;
@@ -402,13 +398,13 @@ namespace ScatterKernelDetail{
           {
             while(ptetry < (b+1)*pagesperblock)
             {
-              uint32 region = ptetry/regionsize;
-              uint32 regionfilllevel = _regions[region];
+              const uint32 region = ptetry/regionsize;
+              const uint32 regionfilllevel = _regions[region];
               if(regionfilllevel < checklevel )
               {
                 for( ; ptetry < (region+1)*regionsize; ++ptetry)
                 {
-                  uint32 chunksize = _ptes[ptetry].chunksize;
+                  const uint32 chunksize = _ptes[ptetry].chunksize;
                   if(chunksize >= bytes && chunksize <= maxchunksize)
                   {
                     void * res = tryUsePage(ptetry, chunksize);
@@ -418,8 +414,8 @@ namespace ScatterKernelDetail{
                   {
                     //lets open up a new page
                     //it is already padded
-                    uint32 new_chunksize = max(bytes,minChunkSize1);
-                    uint32 beforechunksize = atomicCAS((uint32*)&_ptes[ptetry].chunksize, 0, new_chunksize);
+                    const uint32 new_chunksize = max(bytes,minChunkSize1);
+                    const uint32 beforechunksize = atomicCAS((uint32*)&_ptes[ptetry].chunksize, 0, new_chunksize);
                     if(beforechunksize == 0)
                     {
                       void * res = tryUsePage(ptetry, new_chunksize);
@@ -464,31 +460,30 @@ namespace ScatterKernelDetail{
        */
       __device__ void deallocChunked(void* mem, uint32 page, uint32 chunksize)
       {
-        uint32 inpage_offset = ((char*)mem - _page[page].data);
+        const uint32 inpage_offset = ((char*)mem - _page[page].data);
         if(chunksize <= HierarchyThreshold)
         {
           //one more level in hierarchy
-          uint32 segmentsize = chunksize*32 + sizeof(uint32);
-          uint32 fullsegments = min(32,pagesize / segmentsize);
-          uint32 additional_chunks = calcAdditionalChunks(fullsegments,segmentsize,chunksize);
-          uint32 segment = inpage_offset / (chunksize*32);
-          uint32 withinsegment = (inpage_offset - segment*(chunksize*32))/chunksize;
+          const uint32 segmentsize = chunksize*32 + sizeof(uint32);
+          const uint32 fullsegments = min(32,pagesize / segmentsize);
+          const uint32 additional_chunks = calcAdditionalChunks(fullsegments,segmentsize,chunksize);
+          const uint32 segment = inpage_offset / (chunksize*32);
+          const uint32 withinsegment = (inpage_offset - segment*(chunksize*32))/chunksize;
           //mark it as free
-          uint32 nMasks = fullsegments + (additional_chunks > 0 ? 1 : 0);
+          const uint32 nMasks = fullsegments + (additional_chunks > 0 ? 1 : 0);
           uint32* onpagemasks = onPageMasksPosition(page,nMasks);
-          uint32 old = atomicAnd(onpagemasks + segment, ~(1 << withinsegment));
+          uint32 old = atomicAnd(&onpagemasks[segment], ~(1 << withinsegment));
 
           // always do this, since it might fail due to a race-condition with addChunkHierarchy
           atomicAnd((uint32*)&_ptes[page].bitmask, ~(1 << segment));
         }
         else
         {
-          uint32 segment = inpage_offset / chunksize;
+          const uint32 segment = inpage_offset / chunksize;
           atomicAnd((uint32*)&_ptes[page].bitmask, ~(1 << segment));
         }
         //reduce filllevel as free
-        uint32 oldfilllevel = atomicSub((uint32*)&_ptes[page].count, 1);
-
+        const uint32 oldfilllevel = atomicSub((uint32*)&_ptes[page].count, 1);
 
         if(resetfreedpages)
         {
@@ -496,7 +491,7 @@ namespace ScatterKernelDetail{
           {
             //this page now got free!
             // -> try lock it
-            uint32 old = atomicCAS((uint32*)&_ptes[page].count, 0, pagesize);
+            const uint32 old = atomicCAS((uint32*)&_ptes[page].count, 0, pagesize);
             if(old == 0)
             {
               //clean the bits for the hierarchy
@@ -513,9 +508,9 @@ namespace ScatterKernelDetail{
         //meta information counters ... should not be changed by too many threads, so..
         if(oldfilllevel == pagesize / 2 / chunksize)
         {
-          uint32 region = page / regionsize;
+          const uint32 region = page / regionsize;
           _regions[region] = 0;
-          uint32 block = region * regionsize * accessblocks / _numpages ;
+          const uint32 block = region * regionsize * accessblocks / _numpages ;
           if(warpid() + laneid() == 0)
             atomicMin((uint32*)&_firstfreeblock, block);
         }
@@ -533,7 +528,7 @@ namespace ScatterKernelDetail{
         int abord = -1;
         for(uint32 trypage = startpage; trypage < startpage + pages; ++trypage)
         {
-          uint32 old = atomicCAS((uint32*)&_ptes[trypage].chunksize, 0, bytes);
+          const uint32 old = atomicCAS((uint32*)&_ptes[trypage].chunksize, 0, bytes);
           if(old != 0)
           {
             abord = trypage;
@@ -556,7 +551,7 @@ namespace ScatterKernelDetail{
        */
       __device__ void* allocPageBasedSingleRegion(uint32 startpage, uint32 endpage, uint32 bytes)
       {
-        uint32 pagestoalloc = divup(bytes, pagesize);
+        const uint32 pagestoalloc = divup(bytes, pagesize);
         uint32 freecount = 0;
         bool left_free = false;
         for(uint32 search_page = startpage+1; search_page > endpage; )
@@ -596,7 +591,7 @@ namespace ScatterKernelDetail{
         //acquire mutex
         while(atomicExch(&_pagebasedMutex,1) != 0);
         //search for free spot from the back
-        uint32 spage = _firstFreePageBased;
+        const uint32 spage = _firstFreePageBased;
         void* res = allocPageBasedSingleRegion(spage, 0, bytes);
         if(res == 0)
           //also check the rest of the pages
@@ -623,6 +618,7 @@ namespace ScatterKernelDetail{
 #else
           unsigned int __mask = __ballot(1),
 #endif
+            // TODO(bgruber): why the leading __? those names are reserved
           __num = __popc(__mask),
           __lanemask = mallocMC::lanemask_lt(),
           __local_id = __popc(__lanemask & __mask),
@@ -643,7 +639,7 @@ namespace ScatterKernelDetail{
        */
       __device__ void deallocPageBased(void* mem, uint32 page, uint32 bytes)
       {
-        uint32 pages = divup(bytes,pagesize);
+        const uint32 pages = divup(bytes,pagesize);
         for(uint32 p = page; p < page+pages; ++p)
           _page[p].init();
         __threadfence();
@@ -682,13 +678,13 @@ namespace ScatterKernelDetail{
         if(mem == 0)
           return;
         //lets see on which page we are on
-        uint32 page = ((char*)mem - (char*)_page)/pagesize;
-        uint32 chunksize = _ptes[page].chunksize;
+        const uint32 page = ((char*)mem - (char*)_page)/pagesize;
+        const uint32 chunksize = _ptes[page].chunksize;
 
         //is the pointer the beginning of a chunk?
-        uint32 inpage_offset = ((char*)mem - _page[page].data);
-        uint32 block = inpage_offset/chunksize;
-        uint32 inblockoffset = inpage_offset - block*chunksize;
+        const uint32 inpage_offset = ((char*)mem - _page[page].data);
+        const uint32 block = inpage_offset/chunksize;
+        const uint32 inblockoffset = inpage_offset - block*chunksize;
         if(inblockoffset != 0)
         {
           uint32* counter = (uint32*)(_page[page].data + block*chunksize);
@@ -716,14 +712,15 @@ namespace ScatterKernelDetail{
       {
         uint32 linid = threadIdx.x + blockDim.x*(threadIdx.y + threadIdx.z*blockDim.y);
         uint32 threads = blockDim.x*blockDim.y*blockDim.z;
-        uint32 linblockid = blockIdx.x + gridDim.x*(blockIdx.y + blockIdx.z*gridDim.y);
+        const uint32 linblockid = blockIdx.x + gridDim.x*(blockIdx.y + blockIdx.z*gridDim.y);
         uint32 blocks =  gridDim.x*gridDim.y*gridDim.z;
-        linid = linid + linblockid*threads;
+        linid += linblockid*threads;
 
-        uint32 numregions = ((unsigned long long)memsize)/( ((unsigned long long)regionsize)*(sizeof(PTE)+pagesize)+sizeof(uint32));
+        uint32 numregions = ((unsigned long long)memsize)/( ((unsigned long long)regionsize)*(sizeof(PTE)+pagesize)+sizeof(uint32)); // TODO(bgruber): why unsigned long long and not size_t?
+
         uint32 numpages = numregions*regionsize;
         //pointer is copied (copy is called page)
-        PAGE* page = (PAGE*)(memory);
+        PAGE* page = (PAGE*)memory;
         //sec check for alignment
         //copy is checked
         //PointerEquivalent alignmentstatus = ((PointerEquivalent)page) & (16 -1);
@@ -744,7 +741,7 @@ namespace ScatterKernelDetail{
         uint32* regions = (uint32*)(ptes + numpages);
         //sec check for mem size
         //this check refers to the original memory-pointer, which was not adjusted!
-        if( (void*)(regions + numregions) > (((char*)memory) + memsize) )
+        if( (void*)(regions + numregions) > (((char*)memory) + memsize) ) // TODO(bgruber): cast to void* is confusing and looks dangerous
         {
           --numregions;
           numpages = min(numregions*regionsize,numpages);
@@ -757,7 +754,7 @@ namespace ScatterKernelDetail{
         //  printf("c size_t memsize   %llu byte\n", memsize);
         //  printf("c void *memory     %p\n", page);
         //}
-        threads = threads*blocks;
+        threads *= blocks;
 
         for(uint32 i = linid; i < numpages; i+= threads)
         {
@@ -778,24 +775,24 @@ namespace ScatterKernelDetail{
           _pagebasedMutex = 0;
           _firstFreePageBased = numpages-1;
 
-          if( (char*) (_page+numpages) > (char*)(memory) + memsize)
+          if( (char*)&_page[numpages] > (char*)memory + memsize)
             printf("error in heap alloc: numpages too high\n");
         }
 
       }
 
-      __device__ bool isOOM(void* p, size_t s){
+      static __device__ bool isOOM(void* p, size_t s){
         // one thread that requested memory returned null
-        return  s && (p == NULL);
+        return s && (p == nullptr);
       }
 
 
       template < typename T_DeviceAllocator >
       static void* initHeap( T_DeviceAllocator* heap, void* pool, size_t memsize){
-        if( pool == NULL && memsize != 0 )
+        if( pool == nullptr && memsize != 0 )
         {
           throw std::invalid_argument(
-            "Scatter policy cannot use NULL for non-empty memory pools. "
+            "Scatter policy cannot use nullptr for non-empty memory pools. "
             "Maybe you are using an incompatible ReservePoolPolicy or AlignmentPolicy."
           );
         }
@@ -818,16 +815,16 @@ namespace ScatterKernelDetail{
        *        page.
        */
       __device__ unsigned countFreeChunksInPage(uint32 page, uint32 chunksize){
-        uint32 filledChunks = _ptes[page].count;
+        const uint32 filledChunks = _ptes[page].count;
         if(chunksize <= HierarchyThreshold)
         {
-          uint32 segmentsize = chunksize*32 + sizeof(uint32); //each segment can hold 32 2nd-level chunks
-          uint32 fullsegments = min(32,pagesize / segmentsize); //there might be space for more than 32 segments with 32 2nd-level chunks
-          uint32 additional_chunks = calcAdditionalChunks(fullsegments, segmentsize, chunksize);
-          uint32 level2Chunks = fullsegments * 32 + additional_chunks;
+          const uint32 segmentsize = chunksize*32 + sizeof(uint32); //each segment can hold 32 2nd-level chunks
+          const uint32 fullsegments = min(32,pagesize / segmentsize); //there might be space for more than 32 segments with 32 2nd-level chunks
+          const uint32 additional_chunks = calcAdditionalChunks(fullsegments, segmentsize, chunksize);
+          const uint32 level2Chunks = fullsegments * 32 + additional_chunks;
           return level2Chunks - filledChunks;
         }else{
-          uint32 chunksinpage = min(pagesize / chunksize, 32); //without hierarchy, there can not be more than 32 chunks
+          const uint32 chunksinpage = min(pagesize / chunksize, 32); //without hierarchy, there can not be more than 32 chunks
           return chunksinpage - filledChunks;
         }
       }
@@ -854,15 +851,15 @@ namespace ScatterKernelDetail{
         unsigned slotcount = 0;
         if(slotSize < pagesize){ // multiple slots per page
           for(uint32 currentpage = gid; currentpage < _numpages; currentpage += stride){
-            uint32 maxchunksize = min(pagesize, wastefactor*(uint32)slotSize);
-            uint32 region = currentpage/regionsize;
-            uint32 regionfilllevel = _regions[region];
+            const uint32 maxchunksize = min(pagesize, wastefactor*(uint32)slotSize);
+            const uint32 region = currentpage/regionsize;
+            const uint32 regionfilllevel = _regions[region];
 
             uint32 chunksize = _ptes[currentpage].chunksize;
             if(chunksize >= slotSize && chunksize <= maxchunksize){ //how many chunks left? (each chunk is big enough)
               slotcount += countFreeChunksInPage(currentpage, chunksize);
             }else if(chunksize == 0){
-              chunksize  = max((uint32)slotSize, minChunkSize1); //ensure minimum chunk size
+              chunksize = max((uint32)slotSize, minChunkSize1); //ensure minimum chunk size
               slotcount += countFreeChunksInPage(currentpage, chunksize); //how many chunks fit in one page?
             }else{
               continue; //the chunks on this page are too small for the request :(
@@ -870,7 +867,7 @@ namespace ScatterKernelDetail{
           }
         }else{ // 1 slot needs multiple pages
           if(gid > 0) return 0; //do this serially
-          uint32 pagestoalloc = divup((uint32)slotSize, pagesize);
+          const uint32 pagestoalloc = divup((uint32)slotSize, pagesize);
           uint32 freecount = 0;
           for(uint32 currentpage = _numpages; currentpage > 0;){ //this already includes all superblocks
             --currentpage;
@@ -932,13 +929,12 @@ namespace ScatterKernelDetail{
        * @param slotSize the size of allocatable elements to count
        */
       __device__ unsigned getAvailableSlotsAccelerator(size_t slotSize){
-        int linearId;
-        int wId = warpid_withinblock(); //do not use warpid-function, since this value is not guaranteed to be stable across warp lifetime
+        const int wId = warpid_withinblock(); //do not use warpid-function, since this value is not guaranteed to be stable across warp lifetime
 
 #if(__CUDACC_VER_MAJOR__ >= 9)
-        uint32 activeThreads  = __popc(__activemask());
+        const uint32 activeThreads  = __popc(__activemask());
 #else
-        uint32 activeThreads  = __popc(__ballot(true));
+        const uint32 activeThreads  = __popc(__ballot(true));
 #endif
         __shared__ uint32 activePerWarp[MaxThreadsPerBlock::value / WarpSize::value]; //maximum number of warps in a block
         __shared__ unsigned warpResults[MaxThreadsPerBlock::value / WarpSize::value];
@@ -946,16 +942,15 @@ namespace ScatterKernelDetail{
         activePerWarp[wId] = 0;
 
         // the active threads obtain an id from 0 to activeThreads-1
-        if(slotSize>0) linearId = atomicAdd(&activePerWarp[wId], 1);
-        else return 0;
+        if (slotSize == 0) return 0;
+        const int linearId = atomicAdd(&activePerWarp[wId], 1);
 
         //printf("Block %d, id %d: activeThreads=%d linearId=%d\n",blockIdx.x,threadIdx.x,activeThreads,linearId);
-        unsigned temp = getAvailaibleSlotsDeviceFunction(slotSize, linearId, activeThreads);
+        const unsigned temp = getAvailaibleSlotsDeviceFunction(slotSize, linearId, activeThreads);
         if(temp) atomicAdd(&warpResults[wId], temp);
         __threadfence_block();
         return warpResults[wId];
       }
-
 
       static std::string classname(){
         std::stringstream ss;
@@ -971,7 +966,6 @@ namespace ScatterKernelDetail{
         ss << hashingDistWPRel<< "]";
         return ss.str();
       }
-
   };
 
 } //namespace CreationPolicies

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -611,21 +611,16 @@ namespace ScatterKernelDetail{
 
         //only one thread per warp can acquire the mutex
         void* res = 0;
-        for(
 #if(__CUDACC_VER_MAJOR__ >= 9)
-          unsigned int __mask = __activemask(),
+        const unsigned int mask = __activemask();
 #else
-          unsigned int __mask = __ballot(1),
+        const unsigned int mask = __ballot(1);
 #endif
-            // TODO(bgruber): why the leading __? those names are reserved
-          __num = __popc(__mask),
-          __lanemask = mallocMC::lanemask_lt(),
-          __local_id = __popc(__lanemask & __mask),
-          __active = 0;
-          __active < __num;
-          ++__active
-        )
-          if (__active == __local_id)
+        const unsigned int num = __popc(mask);
+        const unsigned int lanemask = mallocMC::lanemask_lt();
+        const unsigned int local_id = __popc(lanemask & mask);
+        for(unsigned int active = 0; active < num; ++active)
+          if (active == local_id)
             res = allocPageBasedSingle(bytes);
         return res;
       }

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -39,7 +39,6 @@
 #include <string>
 #include <cassert>
 #include <stdexcept>
-#include <boost/mpl/bool.hpp>
 
 #include "../mallocMC_utils.hpp"
 #include "Scatter.hpp"
@@ -78,7 +77,7 @@ namespace ScatterKernelDetail{
       typedef T_Config  HeapProperties;
       typedef T_Hashing HashingProperties;
       struct  Properties : HeapProperties, HashingProperties{};
-      typedef boost::mpl::bool_<true>  providesAvailableSlots;
+      static constexpr auto providesAvailableSlots = true;
 
     private:
       using uint32 = std::uint32_t;
@@ -94,27 +93,27 @@ namespace ScatterKernelDetail{
  * default-struct < template-struct < command-line parameter
  */
 #ifndef MALLOCMC_CP_SCATTER_PAGESIZE
-#define MALLOCMC_CP_SCATTER_PAGESIZE  static_cast<uint32>(HeapProperties::pagesize::value)
+#define MALLOCMC_CP_SCATTER_PAGESIZE (HeapProperties::pagesize)
 #endif
       static constexpr uint32 pagesize      = MALLOCMC_CP_SCATTER_PAGESIZE;
 
 #ifndef MALLOCMC_CP_SCATTER_ACCESSBLOCKS
-#define MALLOCMC_CP_SCATTER_ACCESSBLOCKS static_cast<uint32>(HeapProperties::accessblocks::value)
+#define MALLOCMC_CP_SCATTER_ACCESSBLOCKS (HeapProperties::accessblocks)
 #endif
       static constexpr uint32 accessblocks  = MALLOCMC_CP_SCATTER_ACCESSBLOCKS;
 
 #ifndef MALLOCMC_CP_SCATTER_REGIONSIZE
-#define MALLOCMC_CP_SCATTER_REGIONSIZE static_cast<uint32>(HeapProperties::regionsize::value)
+#define MALLOCMC_CP_SCATTER_REGIONSIZE (HeapProperties::regionsize)
 #endif
       static constexpr uint32 regionsize    = MALLOCMC_CP_SCATTER_REGIONSIZE;
 
 #ifndef MALLOCMC_CP_SCATTER_WASTEFACTOR
-#define MALLOCMC_CP_SCATTER_WASTEFACTOR static_cast<uint32>(HeapProperties::wastefactor::value)
+#define MALLOCMC_CP_SCATTER_WASTEFACTOR (HeapProperties::wastefactor)
 #endif
       static constexpr uint32 wastefactor   = MALLOCMC_CP_SCATTER_WASTEFACTOR;
 
 #ifndef MALLOCMC_CP_SCATTER_RESETFREEDPAGES
-#define MALLOCMC_CP_SCATTER_RESETFREEDPAGES static_cast<bool>(HeapProperties::resetfreedpages::value)
+#define MALLOCMC_CP_SCATTER_RESETFREEDPAGES (HeapProperties::resetfreedpages)
 #endif
       static constexpr bool resetfreedpages = MALLOCMC_CP_SCATTER_RESETFREEDPAGES;
 
@@ -137,22 +136,22 @@ namespace ScatterKernelDetail{
       static constexpr uint32 maxOnPageMasks = 32 > tmp_maxOPM ? tmp_maxOPM : 32;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGK
-#define MALLOCMC_CP_SCATTER_HASHINGK    static_cast<uint32>(HashingProperties::hashingK::value)
+#define MALLOCMC_CP_SCATTER_HASHINGK (HashingProperties::hashingK)
 #endif
      static constexpr uint32 hashingK       = MALLOCMC_CP_SCATTER_HASHINGK;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTMP
-#define MALLOCMC_CP_SCATTER_HASHINGDISTMP static_cast<uint32>(HashingProperties::hashingDistMP::value)
+#define MALLOCMC_CP_SCATTER_HASHINGDISTMP (HashingProperties::hashingDistMP)
 #endif
      static constexpr uint32 hashingDistMP  = MALLOCMC_CP_SCATTER_HASHINGDISTMP;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTWP
-#define MALLOCMC_CP_SCATTER_HASHINGDISTWP static_cast<uint32>(HashingProperties::hashingDistWP::value)
+#define MALLOCMC_CP_SCATTER_HASHINGDISTWP (HashingProperties::hashingDistWP)
 #endif
      static constexpr uint32 hashingDistWP  = MALLOCMC_CP_SCATTER_HASHINGDISTWP;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTWPREL
-#define MALLOCMC_CP_SCATTER_HASHINGDISTWPREL static_cast<uint32>(HashingProperties::hashingDistWPRel::value)
+#define MALLOCMC_CP_SCATTER_HASHINGDISTWPREL (HashingProperties::hashingDistWPRel)
 #endif
      static constexpr uint32 hashingDistWPRel = MALLOCMC_CP_SCATTER_HASHINGDISTWPREL;
 

--- a/src/include/mallocMC/device_allocator.hpp
+++ b/src/include/mallocMC/device_allocator.hpp
@@ -33,11 +33,10 @@
 #include "mallocMC_prefixes.hpp"
 #include "mallocMC_traits.hpp"
 
-#include <boost/cstdint.hpp>
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 
 namespace mallocMC{
-
 namespace detail{
 
     /**
@@ -113,7 +112,7 @@ namespace detail{
     class DeviceAllocator :
         public T_CreationPolicy
     {
-        typedef boost::uint32_t uint32;
+        using uint32 = std::uint32_t;
     public:
         typedef T_CreationPolicy CreationPolicy;
         typedef T_DistributionPolicy DistributionPolicy;

--- a/src/include/mallocMC/distributionPolicies/Noop.hpp
+++ b/src/include/mallocMC/distributionPolicies/Noop.hpp
@@ -27,7 +27,6 @@
 
 #pragma once
 
-
 namespace mallocMC{
 namespace DistributionPolicies{
 

--- a/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <string>
 
 #include "Noop.hpp"
@@ -35,27 +35,25 @@
 
 namespace mallocMC{
 namespace DistributionPolicies{
-    
-  class Noop 
+
+  class Noop
   {
-    typedef boost::uint32_t uint32;
+    using uint32 = std::uint32_t;
 
     public:
-
     MAMC_ACCELERATOR
-    uint32 collect(uint32 bytes){
+    uint32 collect(uint32 bytes) const {
       return bytes;
     }
 
     MAMC_ACCELERATOR
-    void* distribute(void* allocatedMem){
+    void* distribute(void* allocatedMem) const {
       return allocatedMem;
     }
 
     static std::string classname(){
       return "Noop";
     }
-
   };
 
 } //namespace DistributionPolicies

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
@@ -33,14 +33,12 @@
 
 #pragma once
 
-#include <boost/mpl/int.hpp>
-
 namespace mallocMC{
 namespace DistributionPolicies{
 
   namespace XMallocSIMDConf{
     struct DefaultXMallocConfig{
-      using pagesize = boost::mpl::int_<4096>;
+      static constexpr auto pagesize = 4096u;
     };
   }
 

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
@@ -37,11 +37,11 @@
 
 namespace mallocMC{
 namespace DistributionPolicies{
-    
+
   namespace XMallocSIMDConf{
     struct DefaultXMallocConfig{
-      typedef boost::mpl::int_<4096>     pagesize;
-    };  
+      using pagesize = boost::mpl::int_<4096>;
+    };
   }
 
   /**
@@ -63,9 +63,8 @@ namespace DistributionPolicies{
    *        default configuration. The default can be obtained through
    *        XMallocSIMD<>::Properties
    */
-  template<class T_Config=XMallocSIMDConf::DefaultXMallocConfig>
+  template<class T_Config = XMallocSIMDConf::DefaultXMallocConfig>
   class XMallocSIMD;
-
 
 } //namespace DistributionPolicies
 } //namespace mallocMC

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
@@ -38,7 +38,7 @@ namespace DistributionPolicies{
 
   namespace XMallocSIMDConf{
     struct DefaultXMallocConfig{
-      static constexpr auto pagesize = 4096u;
+      static constexpr auto pagesize = 4096;
     };
   }
 

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -33,8 +33,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
-#include <boost/static_assert.hpp>
+#include <cstdint>
 #include <limits>
 #include <string>
 #include <sstream>
@@ -51,7 +50,7 @@ namespace DistributionPolicies{
   {
     private:
 
-      typedef boost::uint32_t uint32;
+      using uint32 = std::uint32_t;
       bool can_use_coalescing;
       uint32 warpid;
       uint32 myoffset;
@@ -78,17 +77,17 @@ namespace DistributionPolicies{
 #ifndef MALLOCMC_DP_XMALLOCSIMD_PAGESIZE
 #define MALLOCMC_DP_XMALLOCSIMD_PAGESIZE Properties::pagesize::value
 #endif
-      BOOST_STATIC_CONSTEXPR uint32 pagesize      = MALLOCMC_DP_XMALLOCSIMD_PAGESIZE;
+      static constexpr uint32 pagesize      = MALLOCMC_DP_XMALLOCSIMD_PAGESIZE;
 
       //all the properties must be unsigned integers > 0
-      BOOST_STATIC_ASSERT(!std::numeric_limits<typename Properties::pagesize::type>::is_signed);
+      static_assert(!std::numeric_limits<typename Properties::pagesize::type>::is_signed, "");
 
       // \TODO: The static_cast can be removed once the minimal dependencies of
       //        this project is are at least CUDA 7.0 and gcc 4.8.2
-      BOOST_STATIC_ASSERT(static_cast<uint32>(pagesize) > 0);
+      static_assert(static_cast<uint32>(pagesize) > 0, "");
 
     public:
-      BOOST_STATIC_CONSTEXPR uint32 _pagesize = pagesize;
+      static constexpr uint32 _pagesize = pagesize;
 
       MAMC_ACCELERATOR
       uint32 collect(uint32 bytes){

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -79,9 +79,6 @@ namespace DistributionPolicies{
 #endif
       static constexpr uint32 pagesize      = MALLOCMC_DP_XMALLOCSIMD_PAGESIZE;
 
-      //all the properties must be unsigned integers > 0
-      static_assert(!std::numeric_limits<decltype(Properties::pagesize)>::is_signed, ""); // TODO(bgruber): I think this is too strict. std::is_convertible_v should be enough
-
     public:
       static constexpr uint32 _pagesize = pagesize;
 

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -82,10 +82,6 @@ namespace DistributionPolicies{
       //all the properties must be unsigned integers > 0
       static_assert(!std::numeric_limits<decltype(Properties::pagesize)>::is_signed, ""); // TODO(bgruber): I think this is too strict. std::is_convertible_v should be enough
 
-      // \TODO: The static_cast can be removed once the minimal dependencies of
-      //        this project is are at least CUDA 7.0 and gcc 4.8.2
-      static_assert(pagesize > 0, "");
-
     public:
       static constexpr uint32 _pagesize = pagesize;
 

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -75,16 +75,16 @@ namespace DistributionPolicies{
  * default-struct < template-struct < command-line parameter
  */
 #ifndef MALLOCMC_DP_XMALLOCSIMD_PAGESIZE
-#define MALLOCMC_DP_XMALLOCSIMD_PAGESIZE Properties::pagesize::value
+#define MALLOCMC_DP_XMALLOCSIMD_PAGESIZE (Properties::pagesize)
 #endif
       static constexpr uint32 pagesize      = MALLOCMC_DP_XMALLOCSIMD_PAGESIZE;
 
       //all the properties must be unsigned integers > 0
-      static_assert(!std::numeric_limits<typename Properties::pagesize::type>::is_signed, "");
+      static_assert(!std::numeric_limits<decltype(Properties::pagesize)>::is_signed, ""); // TODO(bgruber): I think this is too strict. std::is_convertible_v should be enough
 
       // \TODO: The static_cast can be removed once the minimal dependencies of
       //        this project is are at least CUDA 7.0 and gcc 4.8.2
-      static_assert(static_cast<uint32>(pagesize) > 0, "");
+      static_assert(pagesize > 0, "");
 
     public:
       static constexpr uint32 _pagesize = pagesize;

--- a/src/include/mallocMC/mallocMC_constraints.hpp
+++ b/src/include/mallocMC/mallocMC_constraints.hpp
@@ -79,7 +79,7 @@ namespace mallocMC{
     typename CreationPolicies::Scatter<x,y>,
     typename DistributionPolicies::XMallocSIMD<z> 
   >{
-    static_assert(x::pagesize == z::pagesize, "Pagesize_must_be_the_same_when_combining_Scatter_and_XMallocSIMD");
+    static_assert(x::pagesize == z::pagesize, "Pagesize must be the same when combining Scatter and XMallocSIMD");
   };
 
 }//namespace mallocMC

--- a/src/include/mallocMC/mallocMC_constraints.hpp
+++ b/src/include/mallocMC/mallocMC_constraints.hpp
@@ -30,7 +30,6 @@
 
 #include "creationPolicies/Scatter.hpp"
 #include "distributionPolicies/XMallocSIMD.hpp"
-#include <boost/mpl/assert.hpp>
 
 namespace mallocMC{
 
@@ -80,8 +79,7 @@ namespace mallocMC{
     typename CreationPolicies::Scatter<x,y>,
     typename DistributionPolicies::XMallocSIMD<z> 
   >{
-    BOOST_MPL_ASSERT_MSG(x::pagesize::value == z::pagesize::value,
-        Pagesize_must_be_the_same_when_combining_Scatter_and_XMallocSIMD, () );
+    static_assert(x::pagesize == z::pagesize, "Pagesize_must_be_the_same_when_combining_Scatter_and_XMallocSIMD");
   };
 
 }//namespace mallocMC

--- a/src/include/mallocMC/mallocMC_traits.hpp
+++ b/src/include/mallocMC/mallocMC_traits.hpp
@@ -31,7 +31,7 @@
 namespace mallocMC{
     template <class T_Allocator>
     struct Traits{
-        static constexpr bool providesAvailableSlots = T_Allocator::CreationPolicy::providesAvailableSlots::value;
+        static constexpr bool providesAvailableSlots = T_Allocator::CreationPolicy::providesAvailableSlots;
     };
 } //namespace mallocMC
 

--- a/src/include/mallocMC/mallocMC_traits.hpp
+++ b/src/include/mallocMC/mallocMC_traits.hpp
@@ -28,15 +28,10 @@
 
 #pragma once
 
-#include <boost/config.hpp>
-
-
 namespace mallocMC{
-
     template <class T_Allocator>
-    struct  Traits{
-        BOOST_STATIC_CONSTEXPR bool providesAvailableSlots = T_Allocator::CreationPolicy::providesAvailableSlots::value;
+    struct Traits{
+        static constexpr bool providesAvailableSlots = T_Allocator::CreationPolicy::providesAvailableSlots::value;
     };
-
 } //namespace mallocMC
 

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -40,10 +40,9 @@
 #include <string>
 #include <sstream>
 #include <stdexcept>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 #include "mallocMC_prefixes.hpp"
-
 
 namespace CUDA
 {
@@ -95,10 +94,8 @@ namespace CUDA
 #define MALLOCMC_CUDA_CHECK_ERROR() CUDA::checkError(__FILE__, __LINE__)
 }
 
-
 namespace mallocMC
 {
-
   template<int PSIZE>
   class __PointerEquivalent
   {
@@ -114,10 +111,9 @@ namespace mallocMC
 
   typedef mallocMC::__PointerEquivalent<sizeof(char*)>::type PointerEquivalent;
 
-
-  MAMC_ACCELERATOR inline boost::uint32_t laneid()
+  MAMC_ACCELERATOR inline std::uint32_t laneid()
   {
-    boost::uint32_t mylaneid;
+    std::uint32_t mylaneid;
     asm("mov.u32 %0, %%laneid;" : "=r" (mylaneid));
     return mylaneid;
   }
@@ -129,9 +125,9 @@ namespace mallocMC
    *
    * @return current index of the warp
    */
-  MAMC_ACCELERATOR inline boost::uint32_t warpid()
+  MAMC_ACCELERATOR inline std::uint32_t warpid()
   {
-    boost::uint32_t mywarpid;
+    std::uint32_t mywarpid;
     asm("mov.u32 %0, %%warpid;" : "=r" (mywarpid));
     return mywarpid;
   }
@@ -140,63 +136,63 @@ namespace mallocMC
    *
    * @return maximum number of warps on a multiprocessor
    */
-  MAMC_ACCELERATOR inline boost::uint32_t nwarpid()
+  MAMC_ACCELERATOR inline std::uint32_t nwarpid()
   {
-    boost::uint32_t mynwarpid;
+    std::uint32_t mynwarpid;
     asm("mov.u32 %0, %%nwarpid;" : "=r" (mynwarpid));
     return mynwarpid;
   }
 
-  MAMC_ACCELERATOR inline boost::uint32_t smid()
+  MAMC_ACCELERATOR inline std::uint32_t smid()
   {
-    boost::uint32_t mysmid;
+    std::uint32_t mysmid;
     asm("mov.u32 %0, %%smid;" : "=r" (mysmid));
     return mysmid;
   }
 
-  MAMC_ACCELERATOR inline boost::uint32_t nsmid()
+  MAMC_ACCELERATOR inline std::uint32_t nsmid()
   {
-    boost::uint32_t mynsmid;
+    std::uint32_t mynsmid;
     asm("mov.u32 %0, %%nsmid;" : "=r" (mynsmid));
     return mynsmid;
   }
-  MAMC_ACCELERATOR inline boost::uint32_t lanemask()
+  MAMC_ACCELERATOR inline std::uint32_t lanemask()
   {
-    boost::uint32_t lanemask;
+    std::uint32_t lanemask;
     asm("mov.u32 %0, %%lanemask_eq;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline boost::uint32_t lanemask_le()
+  MAMC_ACCELERATOR inline std::uint32_t lanemask_le()
   {
-    boost::uint32_t lanemask;
+    std::uint32_t lanemask;
     asm("mov.u32 %0, %%lanemask_le;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline boost::uint32_t lanemask_lt()
+  MAMC_ACCELERATOR inline std::uint32_t lanemask_lt()
   {
-    boost::uint32_t lanemask;
+    std::uint32_t lanemask;
     asm("mov.u32 %0, %%lanemask_lt;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline boost::uint32_t lanemask_ge()
+  MAMC_ACCELERATOR inline std::uint32_t lanemask_ge()
   {
-    boost::uint32_t lanemask;
+    std::uint32_t lanemask;
     asm("mov.u32 %0, %%lanemask_ge;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline boost::uint32_t lanemask_gt()
+  MAMC_ACCELERATOR inline std::uint32_t lanemask_gt()
   {
-    boost::uint32_t lanemask;
+    std::uint32_t lanemask;
     asm("mov.u32 %0, %%lanemask_gt;" : "=r" (lanemask));
     return lanemask;
   }
 
   template<class T>
-  MAMC_HOST MAMC_ACCELERATOR inline T divup(T a, T b) { return (a + b - 1)/b; }
+  MAMC_HOST MAMC_ACCELERATOR inline T divup(T a, T b) { return (a + b - 1) / b; }
 
   /** the maximal number threads per block
    *
@@ -205,7 +201,7 @@ namespace mallocMC
   struct MaxThreadsPerBlock
   {
     // valid for sm_2.X - sm_7.5
-    BOOST_STATIC_CONSTEXPR uint32_t value = 1024;
+    static constexpr uint32_t value = 1024;
   };
 
   /** number of threads within a warp
@@ -215,7 +211,7 @@ namespace mallocMC
   struct WarpSize
   {
     // valid for sm_2.X - sm_7.5
-    BOOST_STATIC_CONSTEXPR uint32_t value = 32;
+    static constexpr uint32_t value = 32;
   };
 
   /** warp id within a cuda block
@@ -225,7 +221,7 @@ namespace mallocMC
    *
    * @return warp id within the block
    */
-  MAMC_ACCELERATOR inline boost::uint32_t warpid_withinblock()
+  MAMC_ACCELERATOR inline std::uint32_t warpid_withinblock()
   {
     return (
       threadIdx.z * blockDim.y * blockDim.x +

--- a/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
@@ -50,8 +50,7 @@ namespace OOMPolicies{
 #undef PM_EXCEPTIONS_NOT_SUPPORTED_HERE
       assert(false);
 #else
-      std::bad_alloc exception;
-      throw exception;
+      throw std::bad_alloc{};
 #endif
       return mem;
     }

--- a/src/include/mallocMC/oOMPolicies/ReturnNull.hpp
+++ b/src/include/mallocMC/oOMPolicies/ReturnNull.hpp
@@ -31,9 +31,9 @@ namespace mallocMC{
 namespace OOMPolicies{
 
   /**
-   * @brief Returns a NULL pointer on OutOfMemory conditions
+   * @brief Returns a nullptr pointer on OutOfMemory conditions
    *
-   * This OOMPolicy will return NULL, if handleOOM() is called.
+   * This OOMPolicy will return nullptr, if handleOOM() is called.
    */
   class ReturnNull;
     

--- a/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
@@ -40,7 +40,7 @@ namespace OOMPolicies{
     public:
       MAMC_ACCELERATOR
       static void* handleOOM(void* mem){
-        return NULL;
+        return nullptr;
       }
 
       static std::string classname(){

--- a/src/include/mallocMC/reservePoolPolicies/CudaSetLimits_impl.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/CudaSetLimits_impl.hpp
@@ -38,10 +38,10 @@ namespace ReservePoolPolicies{
   struct CudaSetLimits{
     static void* setMemPool(size_t memsize){
       cudaDeviceSetLimit(cudaLimitMallocHeapSize, memsize);
-      return NULL;
+      return nullptr;
     }
 
-    static void resetMemPool(void *p=NULL){
+    static void resetMemPool(void *p=nullptr){
       cudaDeviceSetLimit(cudaLimitMallocHeapSize, 8192U);
     }
 

--- a/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
@@ -38,7 +38,7 @@ namespace ReservePoolPolicies{
 
   struct SimpleCudaMalloc{
     static void* setMemPool(size_t memsize){
-      void* pool = NULL;
+      void* pool = nullptr;
       MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc(&pool, memsize));
       return pool;
     }

--- a/tests/verify_heap.cu
+++ b/tests/verify_heap.cu
@@ -38,7 +38,7 @@
 
 // each pointer in the datastructure will point to this many
 // elements of type allocElem_t
-#define ELEMS_PER_SLOT 750
+constexpr auto ELEMS_PER_SLOT = 750;
 
 #include <cuda.h>
 #include <iostream>
@@ -54,7 +54,7 @@
 bool verbose = false;
 
 // the type of the elements to allocate
-typedef unsigned long long allocElem_t;
+using allocElem_t = unsigned long long;
 
 bool run_heap_verification(const size_t, const unsigned, const unsigned, const bool);
 void parse_cmdline(const int, char**, size_t*, unsigned*, unsigned*, bool*);
@@ -66,16 +66,16 @@ struct nullstream : std::ostream {
   nullstream() : std::ostream(0) { }
 };
 
-// uses global verbosity to switch between std::cout and a NULL-output
+// uses global verbosity to switch between std::cout and a nullptr-output
 std::ostream& dout() {
   static nullstream n;
   return verbose ? std::cout : n;
 }
 
 // define some defaults
-BOOST_STATIC_CONSTEXPR unsigned threads_default = 128;
-BOOST_STATIC_CONSTEXPR unsigned blocks_default  = 64;
-BOOST_STATIC_CONSTEXPR size_t heapInMB_default  = 1024; // 1GB
+static constexpr unsigned threads_default = 128;
+static constexpr unsigned blocks_default  = 64;
+static constexpr size_t heapInMB_default  = 1024; // 1GB
 
 
 /**
@@ -103,7 +103,7 @@ int main(int argc, char** argv){
 
   if( computeCapabilityMajor < 2 ) {
     std::cerr << "Error: Compute Capability >= 2.0 required. (is ";
-    std::cerr << computeCapabilityMajor << "."<< computeCapabilityMinor << ")" << std::endl;
+    std::cerr << computeCapabilityMajor << "."<< computeCapabilityMinor << ")\n";
     return 1;
   }
 
@@ -113,10 +113,10 @@ int main(int argc, char** argv){
 
   if(!machine_readable || verbose){
     if(correct){
-      std::cout << "\033[0;32mverification successful ✔\033[0m" << std::endl;
+      std::cout << "\033[0;32mverification successful ✔\033[0m\n";
       return 0;
     }else{
-      std::cerr << "\033[0;31mverification failed\033[0m" << std::endl;
+      std::cerr << "\033[0;31mverification failed\033[0m\n";
       return 1;
     }
   }
@@ -150,8 +150,8 @@ void parse_cmdline(
   for (int i = 1; i < argc; ++i) {
     char* pos = strtok(argv[i], "=");
     std::pair < std::string, std::string > p(std::string(pos), std::string(""));
-    pos = strtok(NULL, "=");
-    if (pos != NULL) {
+    pos = strtok(nullptr, "=");
+    if (pos != nullptr) {
       p.second = std::string(pos);
     }
     parameters.push_back(p);
@@ -197,34 +197,34 @@ void parse_cmdline(
 void print_help(char** argv){
   std::stringstream s;
 
-  s << "SYNOPSIS:"                                              << std::endl;
-  s << argv[0] << " [OPTIONS]"                                  << std::endl;
-  s << ""                                                       << std::endl;
-  s << "OPTIONS:"                                               << std::endl;
-  s << "  -h, --help"                                           << std::endl;
-  s << "    Print this help message and exit"                   << std::endl;
-  s << ""                                                       << std::endl;
-  s << "  -v, --verbose"                                        << std::endl;
-  s << "    Print information about parameters and progress"    << std::endl;
-  s << ""                                                       << std::endl;
-  s << "  -m, --machine_readable"                               << std::endl;
-  s << "    Print all relevant parameters as CSV. This will"    << std::endl;
-  s << "    suppress all other output unless explicitly"        << std::endl;
-  s << "    requested with --verbose or -v"                     << std::endl;
-  s << ""                                                       << std::endl;
-  s << "  --threads=N"                                          << std::endl;
-  s << "    Set the number of threads per block (default "                  ;
-  s <<                               threads_default << "128)"  << std::endl;
-  s << ""                                                       << std::endl;
-  s << "  --blocks=N"                                           << std::endl;
-  s << "    Set the number of blocks in the grid (default "                 ;
-  s <<                                   blocks_default << ")"  << std::endl;
-  s << ""                                                       << std::endl;
-  s << "  --heapsize=N"                                         << std::endl;
-  s << "    Set the heapsize to N Megabyte (default "                       ;
-  s <<                         heapInMB_default << "1024)"      << std::endl;
+  s << "SYNOPSIS:"                                              << '\n';
+  s << argv[0] << " [OPTIONS]"                                  << '\n';
+  s << ""                                                       << '\n';
+  s << "OPTIONS:"                                               << '\n';
+  s << "  -h, --help"                                           << '\n';
+  s << "    Print this help message and exit"                   << '\n';
+  s << ""                                                       << '\n';
+  s << "  -v, --verbose"                                        << '\n';
+  s << "    Print information about parameters and progress"    << '\n';
+  s << ""                                                       << '\n';
+  s << "  -m, --machine_readable"                               << '\n';
+  s << "    Print all relevant parameters as CSV. This will"    << '\n';
+  s << "    suppress all other output unless explicitly"        << '\n';
+  s << "    requested with --verbose or -v"                     << '\n';
+  s << ""                                                       << '\n';
+  s << "  --threads=N"                                          << '\n';
+  s << "    Set the number of threads per block (default "             ;
+  s <<                               threads_default << "128)"  << '\n';
+  s << ""                                                       << '\n';
+  s << "  --blocks=N"                                           << '\n';
+  s << "    Set the number of blocks in the grid (default "            ;
+  s <<                                   blocks_default << ")"  << '\n';
+  s << ""                                                       << '\n';
+  s << "  --heapsize=N"                                         << '\n';
+  s << "    Set the heapsize to N Megabyte (default "                  ;
+  s <<                         heapInMB_default << "1024)"      << '\n';
 
-  std::cout << s.str();
+  std::cout << s.str() << std::flush;
 }
 
 
@@ -256,7 +256,7 @@ __global__ void check_content(
 
   unsigned long long sum=0;
   while(true){
-    size_t pos = atomicAdd(counter,1);
+    const size_t pos = atomicAdd(counter,1);
     if(pos >= nSlots){break;}
     const size_t offset = pos*ELEMS_PER_SLOT;
     for(size_t i=0;i<ELEMS_PER_SLOT;++i){
@@ -331,7 +331,7 @@ __global__ void allocAll(
   unsigned long long sum=0;
   while(true){
     allocElem_t* p = (allocElem_t*) mMC.malloc(sizeof(allocElem_t) * ELEMS_PER_SLOT);
-    if(p == NULL) break;
+    if(p == nullptr) break;
 
     size_t pos = atomicAdd(counter,1);
     const size_t offset = pos*ELEMS_PER_SLOT;
@@ -423,7 +423,7 @@ void allocate(
   MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(h_nSlots,d_nSlots,sizeof(unsigned long long),cudaMemcpyDeviceToHost));
   cudaFree(d_sum);
   cudaFree(d_nSlots);
-  dout() << "done" << std::endl;
+  dout() << "done\n";
 }
 
 
@@ -484,20 +484,20 @@ bool verify(
   MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(&h_counter,d_counter,sizeof(unsigned long long),cudaMemcpyDeviceToHost));
   if(gaussian_sum != h_sum){
     dout() << "\nGaussian Sum doesn't match: is " << h_sum;
-    dout() << " (should be " << gaussian_sum << ")" << std::endl;
+    dout() << " (should be " << gaussian_sum << ")\n";
     h_correct=false;
   }
   if(nSlots != h_counter-(blocks*threads)){
     dout() << "\nallocated number of elements doesn't match: is " << h_counter;
-    dout() << " (should be " << nSlots << ")" << std::endl;
+    dout() << " (should be " << nSlots << ")\n";
     h_correct=false;
   }
   */
 
   if(h_correct){
-    dout() << "done" << std::endl;
+    dout() << "done\n";
   }else{
-    dout() << "failed" << std::endl;
+    dout() << "failed\n";
   }
 
   cudaFree(d_correct);
@@ -583,8 +583,8 @@ void print_machine_readable(
   h << "correct"        ;
   v << correct          ;
 
-  std::cout << h.str() << std::endl;
-  std::cout << v.str() << std::endl;
+  std::cout << h.str() << '\n';
+  std::cout << v.str() << '\n';
 }
 
 
@@ -613,28 +613,28 @@ bool run_heap_verification(
 
   const size_t heapSize         = size_t(1024U*1024U) * heapMB;
   const size_t slotSize         = sizeof(allocElem_t)*ELEMS_PER_SLOT;
-  const size_t nPointers        = ceil(static_cast<float>(heapSize) / slotSize);
+  const size_t nPointers        = (heapSize + slotSize - 1) / slotSize;
   const size_t maxSlots         = heapSize/slotSize;
   const size_t maxSpace         = maxSlots*slotSize + nPointers*sizeof(allocElem_t*);
   bool correct                  = true;
   const unsigned long long zero = 0;
 
-  dout() << "CreationPolicy Arguments:"                                         << std::endl;
-  dout() << "Pagesize:              "     << ScatterConfig::pagesize::value        << std::endl;
-  dout() << "Accessblocks:          "     << ScatterConfig::accessblocks::value    << std::endl;
-  dout() << "Regionsize:            "     << ScatterConfig::regionsize::value      << std::endl;
-  dout() << "Wastefactor:           "     << ScatterConfig::wastefactor::value     << std::endl;
-  dout() << "ResetFreedPages        "     << ScatterConfig::resetfreedpages::value << std::endl;
-  dout() << ""                                                                  << std::endl;
-  dout() << "Gridsize:              "     << blocks                             << std::endl;
-  dout() << "Blocksize:             "     << threads                            << std::endl;
+  dout() << "CreationPolicy Arguments:\n";
+  dout() << "Pagesize:              "     << ScatterConfig::pagesize::value        << '\n';
+  dout() << "Accessblocks:          "     << ScatterConfig::accessblocks::value    << '\n';
+  dout() << "Regionsize:            "     << ScatterConfig::regionsize::value      << '\n';
+  dout() << "Wastefactor:           "     << ScatterConfig::wastefactor::value     << '\n';
+  dout() << "ResetFreedPages        "     << ScatterConfig::resetfreedpages::value << '\n';
+  dout() << "\n";
+  dout() << "Gridsize:              "     << blocks                             << '\n';
+  dout() << "Blocksize:             "     << threads                            << '\n';
   dout() << "Allocated elements:    "     << ELEMS_PER_SLOT << " x "  << sizeof(allocElem_t);
-  dout() << "    Byte ("  << slotSize     << " Byte)"                           << std::endl;
+  dout() << "    Byte ("  << slotSize     << " Byte)\n";
   dout() << "Heap:                  "     << heapSize << " Byte";
-  dout() << " (" << heapSize/pow(1024,2)  << " MByte)"                          << std::endl;
+  dout() << " (" << heapSize/pow(1024,2)  << " MByte)\n";
   dout() << "max space w/ pointers: "     << maxSpace << " Byte";
-  dout() << " (" << maxSpace/pow(1024,2)  << " MByte)"                          << std::endl;
-  dout() << "maximum of elements:   "     << maxSlots                           << std::endl;
+  dout() << " (" << maxSpace/pow(1024,2)  << " MByte)\n";
+  dout() << "maximum of elements:   "     << maxSlots                           << '\n';
 
   // initializing the heap
   ScatterAllocator* mMC = new ScatterAllocator(heapSize);
@@ -649,9 +649,9 @@ bool run_heap_verification(
   const float allocFrac = static_cast<float>(usedSlots)*100/maxSlots;
   const size_t wasted = heapSize - static_cast<size_t>(usedSlots) * slotSize;
   dout() << "allocated elements:    "   << usedSlots;
-  dout() << " (" << allocFrac << "%)"   << std::endl;
+  dout() << " (" << allocFrac << "%)\n";
   dout() << "wasted heap space:     "   << wasted << " Byte";
-  dout() << " (" << wasted/pow(1024,2)  << " MByte)" << std::endl;
+  dout() << " (" << wasted/pow(1024,2)  << " MByte)\n";
 
   // verifying on device
   correct = correct && verify(d_testData,usedSlots,blocks,threads);
@@ -659,7 +659,7 @@ bool run_heap_verification(
   // damaging one cell
   dout() << "damaging of element... ";
   CUDA_CHECK_KERNEL_SYNC(damageElement<<<1,1>>>(d_testData));
-  dout() << "done" << std::endl;
+  dout() << "done\n";
 
   // verifying on device
   // THIS SHOULD FAIL (damage was done before!). Therefore, we must inverse the logic
@@ -676,7 +676,7 @@ bool run_heap_verification(
   cudaFree(d_testData);
   delete mMC;
 
-  dout() << "done "<< std::endl;
+  dout() << "done \n";
 
   if(machine_readable){
     print_machine_readable(

--- a/tests/verify_heap.cu
+++ b/tests/verify_heap.cu
@@ -620,11 +620,11 @@ bool run_heap_verification(
   const unsigned long long zero = 0;
 
   dout() << "CreationPolicy Arguments:\n";
-  dout() << "Pagesize:              "     << ScatterConfig::pagesize::value        << '\n';
-  dout() << "Accessblocks:          "     << ScatterConfig::accessblocks::value    << '\n';
-  dout() << "Regionsize:            "     << ScatterConfig::regionsize::value      << '\n';
-  dout() << "Wastefactor:           "     << ScatterConfig::wastefactor::value     << '\n';
-  dout() << "ResetFreedPages        "     << ScatterConfig::resetfreedpages::value << '\n';
+  dout() << "Pagesize:              "     << ScatterConfig::pagesize        << '\n';
+  dout() << "Accessblocks:          "     << ScatterConfig::accessblocks    << '\n';
+  dout() << "Regionsize:            "     << ScatterConfig::regionsize      << '\n';
+  dout() << "Wastefactor:           "     << ScatterConfig::wastefactor     << '\n';
+  dout() << "ResetFreedPages        "     << ScatterConfig::resetfreedpages << '\n';
   dout() << "\n";
   dout() << "Gridsize:              "     << blocks                             << '\n';
   dout() << "Blocksize:             "     << threads                            << '\n';
@@ -680,11 +680,11 @@ bool run_heap_verification(
 
   if(machine_readable){
     print_machine_readable(
-        ScatterConfig::pagesize::value,
-        ScatterConfig::accessblocks::value,
-        ScatterConfig::regionsize::value,
-        ScatterConfig::wastefactor::value,
-        ScatterConfig::resetfreedpages::value,
+        ScatterConfig::pagesize,
+        ScatterConfig::accessblocks,
+        ScatterConfig::regionsize,
+        ScatterConfig::wastefactor,
+        ScatterConfig::resetfreedpages,
         blocks,
         threads,
         ELEMS_PER_SLOT,

--- a/tests/verify_heap_config.hpp
+++ b/tests/verify_heap_config.hpp
@@ -40,7 +40,7 @@
 
 // configurate the CreationPolicy "Scatter"
 struct ScatterConfig{
-  static constexpr auto pagesize = 4096u;
+  static constexpr auto pagesize = 4096;
   static constexpr auto accessblocks = 8;
   static constexpr auto regionsize = 16;
   static constexpr auto wastefactor = 2;

--- a/tests/verify_heap_config.hpp
+++ b/tests/verify_heap_config.hpp
@@ -28,9 +28,6 @@
 
 #pragma once
 
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/bool.hpp>
-
 // basic files for mallocMC
 #include "src/include/mallocMC/mallocMC_hostclass.hpp"
 
@@ -40,40 +37,39 @@
 #include "src/include/mallocMC/OOMPolicies.hpp"
 #include "src/include/mallocMC/ReservePoolPolicies.hpp"
 #include "src/include/mallocMC/AlignmentPolicies.hpp"
-    
 
 // configurate the CreationPolicy "Scatter"
 struct ScatterConfig{
-    typedef boost::mpl::int_<4096>  pagesize;
-    typedef boost::mpl::int_<8>     accessblocks;
-    typedef boost::mpl::int_<16>    regionsize;
-    typedef boost::mpl::int_<2>     wastefactor;
-    typedef boost::mpl::bool_<false> resetfreedpages;
+  static constexpr auto pagesize = 4096u;
+  static constexpr auto accessblocks = 8;
+  static constexpr auto regionsize = 16;
+  static constexpr auto wastefactor = 2;
+  static constexpr auto resetfreedpages = false;
 };
 
 struct ScatterHashParams{
-    typedef boost::mpl::int_<38183> hashingK;
-    typedef boost::mpl::int_<17497> hashingDistMP;
-    typedef boost::mpl::int_<1>     hashingDistWP;
-    typedef boost::mpl::int_<1>     hashingDistWPRel;
+  static constexpr auto hashingK = 38183;
+  static constexpr auto hashingDistMP = 17497;
+  static constexpr auto hashingDistWP = 1;
+  static constexpr auto hashingDistWPRel = 1;
 };
 
 // configure the DistributionPolicy "XMallocSIMD"
 struct DistributionConfig{
-  typedef ScatterConfig::pagesize pagesize;
+  static constexpr auto pagesize = ScatterConfig::pagesize;
 };
 
 // configure the AlignmentPolicy "Shrink"
 struct AlignmentConfig{
-  typedef boost::mpl::int_<16> dataAlignment;
+  static constexpr auto dataAlignment = 16;
 };
 
 // Define a new allocator and call it ScatterAllocator
 // which resembles the behaviour of ScatterAlloc
-typedef mallocMC::Allocator< 
+using ScatterAllocator = mallocMC::Allocator<
   mallocMC::CreationPolicies::Scatter<ScatterConfig,ScatterHashParams>,
   mallocMC::DistributionPolicies::XMallocSIMD<DistributionConfig>,
   mallocMC::OOMPolicies::ReturnNull,
   mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
   mallocMC::AlignmentPolicies::Shrink<AlignmentConfig>
-  > ScatterAllocator;
+>;


### PR DESCRIPTION
@bussmann has asked my to read a bit into mallocMC, so I spent the afternoon today digging through the code. Since I also love refactoring, I made a few changes on the way.

* requiring C++14
* using cstdint instead of boost/cstdint.hpp
* using std::tuple instead of boost::tuple
* using nullptr
* using static_assert
* using constexpr
* adding const and static where appropriate
* removed a few empty lines
* replaced std::endl by \n where flush was probably not intended
* replaced usage of boost::mpl by static constexpr members
* dropped dependency on boost

All examples and the verifyHeap target build, run and show some meaningful output. But I do not understand the details to be honest.