### PR TITLE
Adding headers to projects and applied clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks:            '*,-llvm-header-guard,-fuchsia-default-arguments-declarations,-cppcoreguidelines-no-malloc,-cppcoreguidelines-owning-memory,-modernize-use-trailing-return-type,-misc-non-private-member-variables-in-classes'
+HeaderFilterRegex: '.*'

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 
 *~
 /nbproject
+/.vs
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ if(NOT DEFINED COMPUTE_CAPABILITY)
   set(COMPUTE_CAPABILITY "30")
 endif()
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch=sm_${COMPUTE_CAPABILITY} -use_fast_math")
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 OPTION(CUDA_OUTPUT_INTERMEDIATE_CODE "Output ptx code" OFF)
 if(CUDA_OUTPUT_INTERMEDIATE_CODE)
@@ -72,9 +71,13 @@ INSTALL(
 ###############################################################################
 # Executables
 ###############################################################################
-add_custom_target(examples DEPENDS mallocMC_Example01 mallocMC_Example02 mallocMC_Example03 VerifyHeap)
+file(GLOB_RECURSE headers src/include/**)
+add_custom_target(mallocMC SOURCES ${headers}) # create a target with the header files for IDE projects
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR}/src/include FILES ${headers})
 
-add_executable(mallocMC_Example01 EXCLUDE_FROM_ALL examples/mallocMC_example01.cu)
+include_directories(${CMAKE_CURRENT_LIST_DIR}/src/include)
+add_executable(mallocMC_Example01 EXCLUDE_FROM_ALL examples/mallocMC_example01.cu examples/mallocMC_example01_config.hpp)
 add_executable(mallocMC_Example02 EXCLUDE_FROM_ALL examples/mallocMC_example02.cu)
 add_executable(mallocMC_Example03 EXCLUDE_FROM_ALL examples/mallocMC_example03.cu)
-add_executable(VerifyHeap EXCLUDE_FROM_ALL tests/verify_heap.cu)
+add_executable(VerifyHeap EXCLUDE_FROM_ALL tests/verify_heap.cu tests/verify_heap_config.hpp)
+add_custom_target(examples DEPENDS mallocMC_Example01 mallocMC_Example02 mallocMC_Example03 VerifyHeap)

--- a/examples/mallocMC_example01.cu
+++ b/examples/mallocMC_example01.cu
@@ -32,7 +32,7 @@
 #include <numeric>
 
 #include <cuda.h>
-#include "mallocMC_example01_config.cu"
+#include "mallocMC_example01_config.hpp"
 
 void run();
 

--- a/examples/mallocMC_example01_config.hpp
+++ b/examples/mallocMC_example01_config.hpp
@@ -29,14 +29,14 @@
 #pragma once
 
 // basic files for mallocMC
-#include "src/include/mallocMC/mallocMC_hostclass.hpp"
+#include <mallocMC/mallocMC_hostclass.hpp>
 
 // Load all available policies for mallocMC
-#include "src/include/mallocMC/CreationPolicies.hpp"
-#include "src/include/mallocMC/DistributionPolicies.hpp"
-#include "src/include/mallocMC/OOMPolicies.hpp"
-#include "src/include/mallocMC/ReservePoolPolicies.hpp"
-#include "src/include/mallocMC/AlignmentPolicies.hpp"
+#include <mallocMC/CreationPolicies.hpp>
+#include <mallocMC/DistributionPolicies.hpp>
+#include <mallocMC/OOMPolicies.hpp>
+#include <mallocMC/ReservePoolPolicies.hpp>
+#include <mallocMC/AlignmentPolicies.hpp>
 
 // configurate the CreationPolicy "Scatter" to modify the default behaviour
 struct ScatterHeapConfig : mallocMC::CreationPolicies::Scatter<>::HeapProperties{

--- a/examples/mallocMC_example02.cu
+++ b/examples/mallocMC_example02.cu
@@ -37,14 +37,14 @@
 // includes for mallocMC
 ///////////////////////////////////////////////////////////////////////////////
 // basic files for mallocMC
-#include "src/include/mallocMC/mallocMC_hostclass.hpp"
+#include <mallocMC/mallocMC_hostclass.hpp>
 
 // Load all available policies for mallocMC
-#include "src/include/mallocMC/CreationPolicies.hpp"
-#include "src/include/mallocMC/DistributionPolicies.hpp"
-#include "src/include/mallocMC/OOMPolicies.hpp"
-#include "src/include/mallocMC/ReservePoolPolicies.hpp"
-#include "src/include/mallocMC/AlignmentPolicies.hpp"
+#include <mallocMC/CreationPolicies.hpp>
+#include <mallocMC/DistributionPolicies.hpp>
+#include <mallocMC/OOMPolicies.hpp>
+#include <mallocMC/ReservePoolPolicies.hpp>
+#include <mallocMC/AlignmentPolicies.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Configuration for mallocMC

--- a/examples/mallocMC_example03.cu
+++ b/examples/mallocMC_example03.cu
@@ -73,13 +73,13 @@ struct AlignmentConfig{
 
 // Define a new mMCator and call it ScatterAllocator
 // which resembles the behaviour of ScatterAlloc
-typedef mallocMC::Allocator<
+using ScatterAllocator = mallocMC::Allocator<
     mallocMC::CreationPolicies::Scatter<ScatterConfig, ScatterHashParams>,
     mallocMC::DistributionPolicies::Noop,
     mallocMC::OOMPolicies::ReturnNull,
     mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
     mallocMC::AlignmentPolicies::Shrink<AlignmentConfig>
-> ScatterAllocator;
+>;
 
 ///////////////////////////////////////////////////////////////////////////////
 // End of mallocMC configuration

--- a/examples/mallocMC_example03.cu
+++ b/examples/mallocMC_example03.cu
@@ -38,14 +38,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 // includes for mallocMC
 ///////////////////////////////////////////////////////////////////////////////
-#include "src/include/mallocMC/mallocMC_hostclass.hpp"
-
-#include "src/include/mallocMC/CreationPolicies.hpp"
-#include "src/include/mallocMC/DistributionPolicies.hpp"
-#include "src/include/mallocMC/OOMPolicies.hpp"
-#include "src/include/mallocMC/ReservePoolPolicies.hpp"
-#include "src/include/mallocMC/AlignmentPolicies.hpp"
-
+#include <mallocMC/mallocMC_hostclass.hpp>
+#include <mallocMC/CreationPolicies.hpp>
+#include <mallocMC/DistributionPolicies.hpp>
+#include <mallocMC/OOMPolicies.hpp>
+#include <mallocMC/ReservePoolPolicies.hpp>
+#include <mallocMC/AlignmentPolicies.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Configuration for mallocMC

--- a/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
@@ -31,8 +31,8 @@
 #include <string>
 #include <tuple>
 
-#include "Noop.hpp"
 #include "../mallocMC_prefixes.hpp"
+#include "Noop.hpp"
 
 namespace mallocMC{
 namespace AlignmentPolicies{

--- a/src/include/mallocMC/alignmentPolicies/Shrink.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink.hpp
@@ -38,7 +38,7 @@ namespace ShrinkConfig{
   struct DefaultShrinkConfig{
     static constexpr auto dataAlignment = 16;
   };
-}
+} // namespace ShrinkConfig
 
   /**
    * @brief Provides proper alignment of pool and pads memory requests

--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -44,7 +44,7 @@ namespace AlignmentPolicies{
 
 namespace Shrink2NS{
     
-  template<int PSIZE> struct __PointerEquivalent{ typedef unsigned int type;};
+  template<int PSIZE> struct __PointerEquivalent{ using type = unsigned int;};
   template<>
   struct __PointerEquivalent<8>{ using type = unsigned long long; };
 } // namespace Shrink2NS

--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -33,11 +33,11 @@
 
 #include <cstdint>
 #include <iostream>
-#include <string>
 #include <sstream>
+#include <string>
 
-#include "Shrink.hpp"
 #include "../mallocMC_prefixes.hpp"
+#include "Shrink.hpp"
 
 namespace mallocMC{
 namespace AlignmentPolicies{
@@ -46,17 +46,17 @@ namespace Shrink2NS{
     
   template<int PSIZE> struct __PointerEquivalent{ typedef unsigned int type;};
   template<>
-  struct __PointerEquivalent<8>{ typedef unsigned long long int type; };
-}// namespace ShrinkNS
+  struct __PointerEquivalent<8>{ using type = unsigned long long; };
+} // namespace Shrink2NS
 
   template<typename T_Config>
   class Shrink{
     public:
-    typedef T_Config Properties;
+    using Properties = T_Config;
 
     private:
     using uint32 = std::uint32_t;
-    typedef Shrink2NS::__PointerEquivalent<sizeof(char*)>::type PointerEquivalent;
+    using PointerEquivalent = Shrink2NS::__PointerEquivalent<sizeof(char*)>::type;
 
 /** Allow for a hierarchical validation of parameters:
  *
@@ -73,7 +73,7 @@ namespace Shrink2NS{
     static constexpr uint32 dataAlignment = MALLOCMC_AP_SHRINK_DATAALIGNMENT;
 
     //dataAlignment must be a power of 2!
-    static_assert(dataAlignment && !(dataAlignment & (dataAlignment-1)), "dataAlignment must also be a power of 2");
+    static_assert(dataAlignment != 0 && (dataAlignment & (dataAlignment-1)) == 0, "dataAlignment must also be a power of 2");
 
     public:
     static std::tuple<void*,size_t> alignPool(void* memory, size_t memsize){

--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -28,15 +28,16 @@
 
 #pragma once
 
-#include "mallocMC_utils.hpp"
+#include "device_allocator.hpp"
+#include "mallocMC_allocator_handle.hpp"
 #include "mallocMC_constraints.hpp"
 #include "mallocMC_prefixes.hpp"
 #include "mallocMC_traits.hpp"
-#include "mallocMC_allocator_handle.hpp"
+#include "mallocMC_utils.hpp"
 
 #include <cstdint>
-#include <tuple>
 #include <sstream>
+#include <tuple>
 #include <vector>
 
 namespace mallocMC{
@@ -71,7 +72,7 @@ namespace detail{
             return T_Allocator::CreationPolicy::getAvailableSlotsHost(slotSize, alloc.getAllocatorHandle().devAllocator);
         }
     };
-}
+}  // namespace detail
 
     struct HeapInfo
     {
@@ -113,18 +114,17 @@ namespace detail{
 
     public:
         typedef T_CreationPolicy CreationPolicy;
-        typedef T_DistributionPolicy DistributionPolicy;
-        typedef T_OOMPolicy OOMPolicy;
-        typedef T_ReservePoolPolicy ReservePoolPolicy;
-        typedef T_AlignmentPolicy AlignmentPolicy;
-        typedef std::vector< HeapInfo > HeapInfoVector;
-        typedef DeviceAllocator<
+        using DistributionPolicy = T_DistributionPolicy;
+        using OOMPolicy = T_OOMPolicy;
+        using ReservePoolPolicy = T_ReservePoolPolicy;
+        using AlignmentPolicy = T_AlignmentPolicy;
+        using HeapInfoVector = std::vector<HeapInfo>;
+        using DevAllocator = DeviceAllocator<
             CreationPolicy,
             DistributionPolicy,
             OOMPolicy,
-            AlignmentPolicy
-        > DevAllocator;
-        typedef AllocatorHandleImpl<Allocator> AllocatorHandle;
+            AlignmentPolicy>;
+        using AllocatorHandle = AllocatorHandleImpl<Allocator>;
 
     private:
         AllocatorHandle allocatorHandle;

--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -113,7 +113,7 @@ namespace detail{
         using uint32 = std::uint32_t;
 
     public:
-        typedef T_CreationPolicy CreationPolicy;
+        using CreationPolicy = T_CreationPolicy;
         using DistributionPolicy = T_DistributionPolicy;
         using OOMPolicy = T_OOMPolicy;
         using ReservePoolPolicy = T_ReservePoolPolicy;

--- a/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
@@ -52,7 +52,7 @@ namespace CreationPolicies{
     }
 
     __device__ bool isOOM(void* p, size_t s) const {
-      return s && (p == nullptr);
+      return s != 0 && (p == nullptr);
     }
 
     template < typename T >

--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -50,7 +50,7 @@ namespace ScatterConf{
     static constexpr auto hashingDistWP = 1;
     static constexpr auto hashingDistWPRel = 1;
   };  
-}
+}  // namespace ScatterConf
 
   /**
    * @brief fast memory allocation based on ScatterAlloc

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -74,7 +74,7 @@ namespace ScatterKernelDetail{
   class Scatter
   {
     public:
-      typedef T_Config  HeapProperties;
+      using HeapProperties = T_Config;
       using HashingProperties = T_Hashing;
       struct  Properties : HeapProperties, HashingProperties{};
       static constexpr auto providesAvailableSlots = true;

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -33,12 +33,12 @@
 
 #pragma once
 
-#include <cstdio>
-#include <cstdint> /* uint32_t */
-#include <iostream>
-#include <string>
 #include <cassert>
+#include <cstdint> /* uint32_t */
+#include <cstdio>
+#include <iostream>
 #include <stdexcept>
+#include <string>
 
 #include "../mallocMC_utils.hpp"
 #include "Scatter.hpp"
@@ -75,7 +75,7 @@ namespace ScatterKernelDetail{
   {
     public:
       typedef T_Config  HeapProperties;
-      typedef T_Hashing HashingProperties;
+      using HashingProperties = T_Hashing;
       struct  Properties : HeapProperties, HashingProperties{};
       static constexpr auto providesAvailableSlots = true;
 

--- a/src/include/mallocMC/device_allocator.hpp
+++ b/src/include/mallocMC/device_allocator.hpp
@@ -28,10 +28,10 @@
 
 #pragma once
 
-#include "mallocMC_utils.hpp"
 #include "mallocMC_constraints.hpp"
 #include "mallocMC_prefixes.hpp"
 #include "mallocMC_traits.hpp"
+#include "mallocMC_utils.hpp"
 
 #include <cstdint>
 #include <cstdio>
@@ -114,10 +114,10 @@ namespace detail{
     {
         using uint32 = std::uint32_t;
     public:
-        typedef T_CreationPolicy CreationPolicy;
-        typedef T_DistributionPolicy DistributionPolicy;
-        typedef T_OOMPolicy OOMPolicy;
-        typedef T_AlignmentPolicy AlignmentPolicy;
+        using CreationPolicy = T_CreationPolicy;
+        using DistributionPolicy = T_DistributionPolicy;
+        using OOMPolicy = T_OOMPolicy;
+        using AlignmentPolicy = T_AlignmentPolicy;
 
         void* pool;
 

--- a/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
@@ -30,8 +30,8 @@
 #include <cstdint>
 #include <string>
 
-#include "Noop.hpp"
 #include "../mallocMC_prefixes.hpp"
+#include "Noop.hpp"
 
 namespace mallocMC{
 namespace DistributionPolicies{

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
@@ -40,7 +40,7 @@ namespace DistributionPolicies{
     struct DefaultXMallocConfig{
       static constexpr auto pagesize = 4096;
     };
-  }
+  } // namespace XMallocSIMDConf
 
   /**
    * @brief SIMD optimized chunk resizing in the style of XMalloc

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -35,11 +35,11 @@
 
 #include <cstdint>
 #include <limits>
-#include <string>
 #include <sstream>
+#include <string>
 
-#include "../mallocMC_utils.hpp"
 #include "../mallocMC_prefixes.hpp"
+#include "../mallocMC_utils.hpp"
 #include "XMallocSIMD.hpp"
 
 namespace mallocMC{
@@ -57,7 +57,7 @@ namespace DistributionPolicies{
       uint32 threadcount;
       uint32 req_size;
     public:
-      typedef T_Config Properties;
+      using Properties = T_Config;
 
       MAMC_ACCELERATOR
       XMallocSIMD() : can_use_coalescing(false), warpid(warpid_withinblock()),

--- a/src/include/mallocMC/mallocMC.hpp
+++ b/src/include/mallocMC/mallocMC.hpp
@@ -43,8 +43,8 @@
 #include "mallocMC_hostclass.hpp"
 
 // all the policies
+#include "AlignmentPolicies.hpp"
 #include "CreationPolicies.hpp"
 #include "DistributionPolicies.hpp"
-#include "ReservePoolPolicies.hpp"
-#include "AlignmentPolicies.hpp"
 #include "OOMPolicies.hpp"
+#include "ReservePoolPolicies.hpp"

--- a/src/include/mallocMC/mallocMC_allocator_handle.hpp
+++ b/src/include/mallocMC/mallocMC_allocator_handle.hpp
@@ -35,11 +35,11 @@ namespace mallocMC{
     template <typename T_HostAllocator>
     struct AllocatorHandleImpl
     {
-        typedef typename T_HostAllocator::DevAllocator DevAllocator;
+        using DevAllocator = typename T_HostAllocator::DevAllocator;
 
         DevAllocator* devAllocator;
 
-        AllocatorHandleImpl(
+        explicit AllocatorHandleImpl(
             DevAllocator* p
         ) :
             devAllocator( p )

--- a/src/include/mallocMC/mallocMC_hostclass.hpp
+++ b/src/include/mallocMC/mallocMC_hostclass.hpp
@@ -28,6 +28,6 @@
 
 #pragma once
 
-#include "mallocMC_traits.hpp"
-#include "device_allocator.hpp"
 #include "allocator.hpp"
+#include "device_allocator.hpp"
+#include "mallocMC_traits.hpp"

--- a/src/include/mallocMC/mallocMC_prefixes.hpp
+++ b/src/include/mallocMC/mallocMC_prefixes.hpp
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <device_launch_parameters.h>
+
 #define MAMC_HOST __host__
 #define MAMC_ACCELERATOR __device__
 

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -102,7 +102,7 @@ namespace mallocMC
   class __PointerEquivalent
   {
   public:
-    typedef unsigned int type;
+    using type = unsigned int;
   };
   template<>
   class __PointerEquivalent<8>

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -33,14 +33,16 @@
 
 #pragma once
 
+#include <cuda_runtime.h>
+
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif
 
-#include <string>
+#include <cstdint>
 #include <sstream>
 #include <stdexcept>
-#include <cstdint>
+#include <string>
 
 #include "mallocMC_prefixes.hpp"
 
@@ -61,12 +63,12 @@ namespace CUDA
     {
     }
 
-    error(cudaError errorValue)
+    explicit error(cudaError errorValue)
       : runtime_error(cudaGetErrorString(errorValue))
     {
     }
 
-    error(const std::string& msg)
+    explicit error(const std::string& msg)
       : runtime_error(msg)
     {
     }
@@ -92,7 +94,7 @@ namespace CUDA
 
 #define MALLOCMC_CUDA_CHECKED_CALL(call) CUDA::checkError(call, __FILE__, __LINE__)
 #define MALLOCMC_CUDA_CHECK_ERROR() CUDA::checkError(__FILE__, __LINE__)
-}
+}  // namespace CUDA
 
 namespace mallocMC
 {
@@ -106,10 +108,10 @@ namespace mallocMC
   class __PointerEquivalent<8>
   {
   public:
-    typedef unsigned long long int type;
+    using type = unsigned long long;
   };
 
-  typedef mallocMC::__PointerEquivalent<sizeof(char*)>::type PointerEquivalent;
+  using PointerEquivalent = mallocMC::__PointerEquivalent<sizeof(char*)>::type;
 
   MAMC_ACCELERATOR inline std::uint32_t laneid()
   {
@@ -229,4 +231,4 @@ namespace mallocMC
       threadIdx.x
     ) / WarpSize::value;
   }
-}
+}  // namespace mallocMC

--- a/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
@@ -30,8 +30,8 @@
 #include <cassert>
 #include <string>
 
-#include "BadAllocException.hpp"
 #include "../mallocMC_prefixes.hpp"
+#include "BadAllocException.hpp"
 
 namespace mallocMC{
 namespace OOMPolicies{

--- a/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
@@ -29,8 +29,8 @@
 
 #include <string>
 
-#include "ReturnNull.hpp"
 #include "../mallocMC_prefixes.hpp"
+#include "ReturnNull.hpp"
 
 namespace mallocMC{
 namespace OOMPolicies{

--- a/tests/verify_heap.cu
+++ b/tests/verify_heap.cu
@@ -45,9 +45,10 @@ constexpr auto ELEMS_PER_SLOT = 750;
 #include <cstdio>
 #include <typeinfo>
 #include <vector>
+#include <sstream>
 
 //include the Heap with the arguments given in the config
-#include "src/include/mallocMC/mallocMC_utils.hpp"
+#include <mallocMC/mallocMC_utils.hpp>
 #include "verify_heap_config.hpp"
 
 // global variable for verbosity, might change due to user input '--verbose'

--- a/tests/verify_heap_config.hpp
+++ b/tests/verify_heap_config.hpp
@@ -29,14 +29,14 @@
 #pragma once
 
 // basic files for mallocMC
-#include "src/include/mallocMC/mallocMC_hostclass.hpp"
+#include <mallocMC/mallocMC_hostclass.hpp>
 
 // Load all available policies for mallocMC
-#include "src/include/mallocMC/CreationPolicies.hpp"
-#include "src/include/mallocMC/DistributionPolicies.hpp"
-#include "src/include/mallocMC/OOMPolicies.hpp"
-#include "src/include/mallocMC/ReservePoolPolicies.hpp"
-#include "src/include/mallocMC/AlignmentPolicies.hpp"
+#include <mallocMC/CreationPolicies.hpp>
+#include <mallocMC/DistributionPolicies.hpp>
+#include <mallocMC/OOMPolicies.hpp>
+#include <mallocMC/ReservePoolPolicies.hpp>
+#include <mallocMC/AlignmentPolicies.hpp>
 
 // configurate the CreationPolicy "Scatter"
 struct ScatterConfig{


### PR DESCRIPTION
* added a custom target for mallocMC headers, this makes the headers show up in IDE projects (e.g. Visual Studio)
* added header files to their respective projects (exampels and VerifyHeap)
* applied clang-tidy
* using global includes in examples and tests for mallocMC headers