### PR TITLE
clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,76 @@
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands: false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: All
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: true
+ColumnLimit: 0
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+FixNamespaceComments: false
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
+NamespaceIndentation: All
+PointerAlignment: Middle
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+UseTab: Never
+...

--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
+AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
@@ -38,7 +38,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
 BreakStringLiterals: true
-ColumnLimit: 0
+ColumnLimit: 80
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 8
@@ -46,6 +46,7 @@ ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 FixNamespaceComments: false
+IncludeBlocks: Regroup
 IndentCaseLabels: false
 IndentPPDirectives: None
 IndentWidth: 4

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
 ---
-Checks:            '*,-llvm-header-guard,-fuchsia-default-arguments-declarations,-cppcoreguidelines-no-malloc,-cppcoreguidelines-owning-memory,-modernize-use-trailing-return-type,-misc-non-private-member-variables-in-classes'
+Checks:            '*,-llvm-header-guard,-fuchsia-default-arguments-declarations,-cppcoreguidelines-no-malloc,-cppcoreguidelines-owning-memory,-misc-non-private-member-variables-in-classes'
 HeaderFilterRegex: '.*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Formatting
+
+Please format your code before before opening pull requests using clang-format and the .clang-format file placed in the repository root.
+
+### Visual Studio and CLion
+Suport for clang-format is built-in since Visual Studio 2017 15.7 and CLion 2019.1.
+The .clang-format file in the repository will be automatically detected and formatting is done as you type, or triggered when pressing the format hotkey.
+
+### Bash
+First install clang-format. Instructions therefore can be found on the web. To format you can run this command in bash:
+```
+find -iname *.cu -o -iname *.hpp | xargs clang-format-10 -i
+```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ mallocMC is header-only, but requires a few other C++ libraries to be
 available. Our installation notes can be found in [INSTALL.md](INSTALL.md).
 
 
+Contributing
+------------
+
+Rules for contributions are found in [CONTRIBUTING.md](CONTRIBUTING.md).
+
 On the ScatterAlloc Algorithm
 -----------------------------
 

--- a/examples/mallocMC_example01.cu
+++ b/examples/mallocMC_example01.cu
@@ -36,7 +36,7 @@
 
 void run();
 
-int main()
+auto main() -> int
 {
     int computeCapabilityMajor = 0;
     cudaDeviceGetAttribute(

--- a/examples/mallocMC_example01_config.hpp
+++ b/examples/mallocMC_example01_config.hpp
@@ -32,44 +32,48 @@
 #include <mallocMC/mallocMC_hostclass.hpp>
 
 // Load all available policies for mallocMC
+#include <mallocMC/AlignmentPolicies.hpp>
 #include <mallocMC/CreationPolicies.hpp>
 #include <mallocMC/DistributionPolicies.hpp>
 #include <mallocMC/OOMPolicies.hpp>
 #include <mallocMC/ReservePoolPolicies.hpp>
-#include <mallocMC/AlignmentPolicies.hpp>
 
 // configurate the CreationPolicy "Scatter" to modify the default behaviour
-struct ScatterHeapConfig : mallocMC::CreationPolicies::Scatter<>::HeapProperties{
-  static constexpr auto pagesize = 4096;
-  static constexpr auto accessblocks = 8;
-  static constexpr auto regionsize = 16;
-  static constexpr auto wastefactor = 2;
-  static constexpr auto resetfreedpages = false;
+struct ScatterHeapConfig : mallocMC::CreationPolicies::Scatter<>::HeapProperties
+{
+    static constexpr auto pagesize = 4096;
+    static constexpr auto accessblocks = 8;
+    static constexpr auto regionsize = 16;
+    static constexpr auto wastefactor = 2;
+    static constexpr auto resetfreedpages = false;
 };
 
-struct ScatterHashConfig : mallocMC::CreationPolicies::Scatter<>::HashingProperties{
-  static constexpr auto hashingK = 38183;
-  static constexpr auto hashingDistMP = 17497;
-  static constexpr auto hashingDistWP = 1;
-  static constexpr auto hashingDistWPRel = 1;
+struct ScatterHashConfig :
+        mallocMC::CreationPolicies::Scatter<>::HashingProperties
+{
+    static constexpr auto hashingK = 38183;
+    static constexpr auto hashingDistMP = 17497;
+    static constexpr auto hashingDistWP = 1;
+    static constexpr auto hashingDistWPRel = 1;
 };
 
 // configure the DistributionPolicy "XMallocSIMD"
-struct XMallocConfig : mallocMC::DistributionPolicies::XMallocSIMD<>::Properties {
-  static constexpr auto pagesize = ScatterHeapConfig::pagesize;
+struct XMallocConfig : mallocMC::DistributionPolicies::XMallocSIMD<>::Properties
+{
+    static constexpr auto pagesize = ScatterHeapConfig::pagesize;
 };
 
 // configure the AlignmentPolicy "Shrink"
-struct ShrinkConfig : mallocMC::AlignmentPolicies::Shrink<>::Properties {
-  static constexpr auto dataAlignment = 16;
+struct ShrinkConfig : mallocMC::AlignmentPolicies::Shrink<>::Properties
+{
+    static constexpr auto dataAlignment = 16;
 };
 
 // Define a new allocator and call it ScatterAllocator
 // which resembles the behaviour of ScatterAlloc
 using ScatterAllocator = mallocMC::Allocator<
-  mallocMC::CreationPolicies::Scatter<ScatterHeapConfig, ScatterHashConfig>,
-  mallocMC::DistributionPolicies::XMallocSIMD<XMallocConfig>,
-  mallocMC::OOMPolicies::ReturnNull,
-  mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
-  mallocMC::AlignmentPolicies::Shrink<ShrinkConfig>
->;
+    mallocMC::CreationPolicies::Scatter<ScatterHeapConfig, ScatterHashConfig>,
+    mallocMC::DistributionPolicies::XMallocSIMD<XMallocConfig>,
+    mallocMC::OOMPolicies::ReturnNull,
+    mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
+    mallocMC::AlignmentPolicies::Shrink<ShrinkConfig>>;

--- a/examples/mallocMC_example02.cu
+++ b/examples/mallocMC_example02.cu
@@ -94,7 +94,7 @@ using ScatterAllocator = mallocMC::Allocator<
 
 void run();
 
-int main()
+auto main() -> int
 {
     int computeCapabilityMajor = 0;
     cudaDeviceGetAttribute(

--- a/examples/mallocMC_example02.cu
+++ b/examples/mallocMC_example02.cu
@@ -26,12 +26,11 @@
   THE SOFTWARE.
 */
 
-#include <iostream>
 #include <cassert>
-#include <vector>
-#include <numeric>
-
 #include <cuda.h>
+#include <iostream>
+#include <numeric>
+#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 // includes for mallocMC
@@ -40,70 +39,75 @@
 #include <mallocMC/mallocMC_hostclass.hpp>
 
 // Load all available policies for mallocMC
+#include <mallocMC/AlignmentPolicies.hpp>
 #include <mallocMC/CreationPolicies.hpp>
 #include <mallocMC/DistributionPolicies.hpp>
 #include <mallocMC/OOMPolicies.hpp>
 #include <mallocMC/ReservePoolPolicies.hpp>
-#include <mallocMC/AlignmentPolicies.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Configuration for mallocMC
 ///////////////////////////////////////////////////////////////////////////////
 
 // configurate the CreationPolicy "Scatter"
-struct ScatterConfig{
-  static constexpr auto pagesize = 4096;
-  static constexpr auto accessblocks = 8;
-  static constexpr auto regionsize = 16;
-  static constexpr auto wastefactor = 2;
-  static constexpr auto resetfreedpages = false;
+struct ScatterConfig
+{
+    static constexpr auto pagesize = 4096;
+    static constexpr auto accessblocks = 8;
+    static constexpr auto regionsize = 16;
+    static constexpr auto wastefactor = 2;
+    static constexpr auto resetfreedpages = false;
 };
 
-struct ScatterHashParams{
-  static constexpr auto hashingK = 38183;
-  static constexpr auto hashingDistMP = 17497;
-  static constexpr auto hashingDistWP = 1;
-  static constexpr auto hashingDistWPRel = 1;
+struct ScatterHashParams
+{
+    static constexpr auto hashingK = 38183;
+    static constexpr auto hashingDistMP = 17497;
+    static constexpr auto hashingDistWP = 1;
+    static constexpr auto hashingDistWPRel = 1;
 };
 
 // configure the DistributionPolicy "XMallocSIMD"
-struct DistributionConfig{
-  static constexpr auto pagesize = ScatterConfig::pagesize;
+struct DistributionConfig
+{
+    static constexpr auto pagesize = ScatterConfig::pagesize;
 };
 
 // configure the AlignmentPolicy "Shrink"
-struct AlignmentConfig{
-  static constexpr auto dataAlignment = 16;
+struct AlignmentConfig
+{
+    static constexpr auto dataAlignment = 16;
 };
 
 // Define a new mMCator and call it ScatterAllocator
 // which resembles the behaviour of ScatterAlloc
 using ScatterAllocator = mallocMC::Allocator<
-  mallocMC::CreationPolicies::Scatter<ScatterConfig,ScatterHashParams>,
-  mallocMC::DistributionPolicies::XMallocSIMD<DistributionConfig>,
-  mallocMC::OOMPolicies::ReturnNull,
-  mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
-  mallocMC::AlignmentPolicies::Shrink<AlignmentConfig>
->;
-
+    mallocMC::CreationPolicies::Scatter<ScatterConfig, ScatterHashParams>,
+    mallocMC::DistributionPolicies::XMallocSIMD<DistributionConfig>,
+    mallocMC::OOMPolicies::ReturnNull,
+    mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
+    mallocMC::AlignmentPolicies::Shrink<AlignmentConfig>>;
 
 ///////////////////////////////////////////////////////////////////////////////
 // End of mallocMC configuration
 ///////////////////////////////////////////////////////////////////////////////
-
 
 void run();
 
 int main()
 {
     int computeCapabilityMajor = 0;
-    cudaDeviceGetAttribute(&computeCapabilityMajor, cudaDevAttrComputeCapabilityMajor, 0);
+    cudaDeviceGetAttribute(
+        &computeCapabilityMajor, cudaDevAttrComputeCapabilityMajor, 0);
     int computeCapabilityMinor = 0;
-    cudaDeviceGetAttribute(&computeCapabilityMinor, cudaDevAttrComputeCapabilityMinor, 0);
+    cudaDeviceGetAttribute(
+        &computeCapabilityMinor, cudaDevAttrComputeCapabilityMinor, 0);
 
-    if( computeCapabilityMajor < int(2) ) {
+    if(computeCapabilityMajor < int(2))
+    {
         std::cerr << "Error: Compute Capability >= 2.0 required. (is ";
-        std::cerr << computeCapabilityMajor << "."<< computeCapabilityMinor << ")" << std::endl;
+        std::cerr << computeCapabilityMajor << "." << computeCapabilityMinor
+                  << ")" << std::endl;
         return 1;
     }
 
@@ -114,106 +118,110 @@ int main()
     return 0;
 }
 
+__device__ int ** arA;
+__device__ int ** arB;
+__device__ int ** arC;
 
-__device__ int** arA;
-__device__ int** arB;
-__device__ int** arC;
-
-
-__global__ void createArrayPointers(int x, int y, ScatterAllocator::AllocatorHandle  mMC){
-    arA = (int**) mMC.malloc(sizeof(int*) * x*y);
-    arB = (int**) mMC.malloc(sizeof(int*) * x*y);
-    arC = (int**) mMC.malloc(sizeof(int*) * x*y);
+__global__ void
+createArrayPointers(int x, int y, ScatterAllocator::AllocatorHandle mMC)
+{
+    arA = (int **)mMC.malloc(sizeof(int *) * x * y);
+    arB = (int **)mMC.malloc(sizeof(int *) * x * y);
+    arC = (int **)mMC.malloc(sizeof(int *) * x * y);
 }
 
+__global__ void
+fillArrays(int length, int * d, ScatterAllocator::AllocatorHandle mMC)
+{
+    int id = threadIdx.x + blockIdx.x * blockDim.x;
 
-__global__ void fillArrays(int length, int* d, ScatterAllocator::AllocatorHandle mMC){
-    int id = threadIdx.x + blockIdx.x*blockDim.x;
+    arA[id] = (int *)mMC.malloc(sizeof(int) * length);
+    arB[id] = (int *)mMC.malloc(sizeof(int) * length);
+    arC[id] = (int *)mMC.malloc(sizeof(int) * length);
 
-    arA[id] = (int*) mMC.malloc(sizeof(int)*length);
-    arB[id] = (int*) mMC.malloc(sizeof(int)*length);
-    arC[id] = (int*) mMC.malloc(sizeof(int)*length);
-
-    for(int i=0 ; i<length; ++i){
-        arA[id][i] = id*length+i;
-        arB[id][i] = id*length+i;
+    for(int i = 0; i < length; ++i)
+    {
+        arA[id][i] = id * length + i;
+        arB[id][i] = id * length + i;
     }
 }
 
-
-__global__ void addArrays(int length, int* d){
-    int id = threadIdx.x + blockIdx.x*blockDim.x;
+__global__ void addArrays(int length, int * d)
+{
+    int id = threadIdx.x + blockIdx.x * blockDim.x;
 
     d[id] = 0;
-    for(int i=0 ; i<length; ++i){
+    for(int i = 0; i < length; ++i)
+    {
         arC[id][i] = arA[id][i] + arB[id][i];
         d[id] += arC[id][i];
     }
 }
 
-
-__global__ void freeArrays(ScatterAllocator::AllocatorHandle mMC){
-    int id = threadIdx.x + blockIdx.x*blockDim.x;
+__global__ void freeArrays(ScatterAllocator::AllocatorHandle mMC)
+{
+    int id = threadIdx.x + blockIdx.x * blockDim.x;
     mMC.free(arA[id]);
     mMC.free(arB[id]);
     mMC.free(arC[id]);
 }
 
-
-__global__ void freeArrayPointers(ScatterAllocator::AllocatorHandle mMC){
+__global__ void freeArrayPointers(ScatterAllocator::AllocatorHandle mMC)
+{
     mMC.free(arA);
     mMC.free(arB);
     mMC.free(arC);
 }
-
 
 void run()
 {
     size_t block = 32;
     size_t grid = 32;
     int length = 100;
-    assert((unsigned)length <= block*grid); //necessary for used algorithm
+    assert((unsigned)length <= block * grid); // necessary for used algorithm
 
-    //init the heap
+    // init the heap
     std::cerr << "initHeap...";
-    ScatterAllocator mMC(1U*1024U*1024U*1024U); //1GB for device-side malloc
+    ScatterAllocator mMC(
+        1U * 1024U * 1024U * 1024U); // 1GB for device-side malloc
     std::cerr << "done" << std::endl;
 
     // device-side pointers
-    int*  d;
-    cudaMalloc((void**) &d, sizeof(int)*block*grid);
+    int * d;
+    cudaMalloc((void **)&d, sizeof(int) * block * grid);
 
     // host-side pointers
-    std::vector<int> array_sums(block*grid,0);
+    std::vector<int> array_sums(block * grid, 0);
 
     // create arrays of arrays on the device
-    createArrayPointers<<<1,1>>>(grid, block, mMC );
+    createArrayPointers<<<1, 1>>>(grid, block, mMC);
 
     // fill 2 of them all with ascending values
-    fillArrays<<<grid,block>>>(length, d, mMC );
+    fillArrays<<<grid, block>>>(length, d, mMC);
 
     // add the 2 arrays (vector addition within each thread)
     // and do a thread-wise reduce to d
-    addArrays<<<grid,block>>>(length, d);
+    addArrays<<<grid, block>>>(length, d);
 
-    cudaMemcpy(&array_sums[0], d, sizeof(int)*block*grid, cudaMemcpyDeviceToHost);
+    cudaMemcpy(
+        &array_sums[0], d, sizeof(int) * block * grid, cudaMemcpyDeviceToHost);
 
     int sum = std::accumulate(array_sums.begin(), array_sums.end(), 0);
     std::cout << "The sum of the arrays on GPU is " << sum << std::endl;
 
-    int n = block*grid*length;
-    int gaussian = n*(n-1);
+    int n = block * grid * length;
+    int gaussian = n * (n - 1);
     std::cout << "The gaussian sum as comparison: " << gaussian << std::endl;
 
     // checking the free memory of the allocator
-    if(mallocMC::Traits<ScatterAllocator>::providesAvailableSlots){
+    if(mallocMC::Traits<ScatterAllocator>::providesAvailableSlots)
+    {
         std::cout << "there are ";
-        std::cout << mMC.getAvailableSlots(1024U*1024U);
+        std::cout << mMC.getAvailableSlots(1024U * 1024U);
         std::cout << " Slots of size 1MB available" << std::endl;
     }
 
-    freeArrays<<<grid, block>>>( mMC );
-    freeArrayPointers<<<1, 1>>>( mMC );
+    freeArrays<<<grid, block>>>(mMC);
+    freeArrayPointers<<<1, 1>>>(mMC);
     cudaFree(d);
-
 }

--- a/examples/mallocMC_example03.cu
+++ b/examples/mallocMC_example03.cu
@@ -101,7 +101,7 @@ __global__ void exampleKernel(ScatterAllocator::AllocatorHandle mMC)
         mMC.free(arA);
 }
 
-int main()
+auto main() -> int
 {
     ScatterAllocator mMC(
         1U * 1024U * 1024U * 1024U); // 1GB for device-side malloc

--- a/src/include/mallocMC/AlignmentPolicies.hpp
+++ b/src/include/mallocMC/AlignmentPolicies.hpp
@@ -28,9 +28,7 @@
 
 #pragma once
 
-#include "alignmentPolicies/Shrink.hpp"
-#include "alignmentPolicies/Shrink_impl.hpp"
-
 #include "alignmentPolicies/Noop.hpp"
 #include "alignmentPolicies/Noop_impl.hpp"
-
+#include "alignmentPolicies/Shrink.hpp"
+#include "alignmentPolicies/Shrink_impl.hpp"

--- a/src/include/mallocMC/CreationPolicies.hpp
+++ b/src/include/mallocMC/CreationPolicies.hpp
@@ -28,8 +28,7 @@
 
 #pragma once
 
-#include "creationPolicies/Scatter.hpp"
-#include "creationPolicies/Scatter_impl.hpp"
-
 #include "creationPolicies/OldMalloc.hpp"
 #include "creationPolicies/OldMalloc_impl.hpp"
+#include "creationPolicies/Scatter.hpp"
+#include "creationPolicies/Scatter_impl.hpp"

--- a/src/include/mallocMC/DistributionPolicies.hpp
+++ b/src/include/mallocMC/DistributionPolicies.hpp
@@ -30,6 +30,5 @@
 
 #include "distributionPolicies/Noop.hpp"
 #include "distributionPolicies/Noop_impl.hpp"
-
 #include "distributionPolicies/XMallocSIMD.hpp"
 #include "distributionPolicies/XMallocSIMD_impl.hpp"

--- a/src/include/mallocMC/OOMPolicies.hpp
+++ b/src/include/mallocMC/OOMPolicies.hpp
@@ -28,8 +28,7 @@
 
 #pragma once
 
-#include "oOMPolicies/ReturnNull.hpp"
-#include "oOMPolicies/ReturnNull_impl.hpp"
-
 #include "oOMPolicies/BadAllocException.hpp"
 #include "oOMPolicies/BadAllocException_impl.hpp"
+#include "oOMPolicies/ReturnNull.hpp"
+#include "oOMPolicies/ReturnNull_impl.hpp"

--- a/src/include/mallocMC/ReservePoolPolicies.hpp
+++ b/src/include/mallocMC/ReservePoolPolicies.hpp
@@ -28,8 +28,7 @@
 
 #pragma once
 
-#include "reservePoolPolicies/SimpleCudaMalloc.hpp"
-#include "reservePoolPolicies/SimpleCudaMalloc_impl.hpp"
-
 #include "reservePoolPolicies/CudaSetLimits.hpp"
 #include "reservePoolPolicies/CudaSetLimits_impl.hpp"
+#include "reservePoolPolicies/SimpleCudaMalloc.hpp"
+#include "reservePoolPolicies/SimpleCudaMalloc_impl.hpp"

--- a/src/include/mallocMC/alignmentPolicies/Noop.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Noop.hpp
@@ -27,16 +27,17 @@
 
 #pragma once
 
-namespace mallocMC{
-namespace AlignmentPolicies{
+namespace mallocMC
+{
+    namespace AlignmentPolicies
+    {
+        /**
+         * @brief a policy that does nothing
+         *
+         * This AlignmentPolicy will not perform any distribution, but only
+         * return its input (identity function)
+         */
+        class Noop;
 
-  /**
-   * @brief a policy that does nothing
-   *
-   * This AlignmentPolicy will not perform any distribution, but only return
-   * its input (identity function)
-   */
-  class Noop;
-
-} //namespace AlignmentPolicies
-} //namespace mallocMC
+    } // namespace AlignmentPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
@@ -43,13 +43,14 @@ namespace mallocMC
             using uint32 = std::uint32_t;
 
         public:
-            static auto
-            alignPool(void * memory, size_t memsize) -> std::tuple<void *, size_t>
+            static auto alignPool(void * memory, size_t memsize)
+                -> std::tuple<void *, size_t>
             {
                 return std::make_tuple(memory, memsize);
             }
 
-            MAMC_HOST MAMC_ACCELERATOR static auto applyPadding(uint32 bytes) -> uint32
+            MAMC_HOST MAMC_ACCELERATOR static auto applyPadding(uint32 bytes)
+                -> uint32
             {
                 return bytes;
             }

--- a/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
@@ -43,18 +43,18 @@ namespace mallocMC
             using uint32 = std::uint32_t;
 
         public:
-            static std::tuple<void *, size_t>
-            alignPool(void * memory, size_t memsize)
+            static auto
+            alignPool(void * memory, size_t memsize) -> std::tuple<void *, size_t>
             {
                 return std::make_tuple(memory, memsize);
             }
 
-            MAMC_HOST MAMC_ACCELERATOR static uint32 applyPadding(uint32 bytes)
+            MAMC_HOST MAMC_ACCELERATOR static auto applyPadding(uint32 bytes) -> uint32
             {
                 return bytes;
             }
 
-            static std::string classname()
+            static auto classname() -> std::string
             {
                 return "Noop";
             }

--- a/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
@@ -27,34 +27,38 @@
 
 #pragma once
 
+#include "../mallocMC_prefixes.hpp"
+#include "Noop.hpp"
+
 #include <cstdint>
 #include <string>
 #include <tuple>
 
-#include "../mallocMC_prefixes.hpp"
-#include "Noop.hpp"
+namespace mallocMC
+{
+    namespace AlignmentPolicies
+    {
+        class Noop
+        {
+            using uint32 = std::uint32_t;
 
-namespace mallocMC{
-namespace AlignmentPolicies{
+        public:
+            static std::tuple<void *, size_t>
+            alignPool(void * memory, size_t memsize)
+            {
+                return std::make_tuple(memory, memsize);
+            }
 
-  class Noop{
-    using uint32 = std::uint32_t;
+            MAMC_HOST MAMC_ACCELERATOR static uint32 applyPadding(uint32 bytes)
+            {
+                return bytes;
+            }
 
-    public:
+            static std::string classname()
+            {
+                return "Noop";
+            }
+        };
 
-    static std::tuple<void*,size_t> alignPool(void* memory, size_t memsize){
-      return std::make_tuple(memory, memsize);
-    }
-
-    MAMC_HOST MAMC_ACCELERATOR
-    static uint32 applyPadding(uint32 bytes){
-      return bytes;
-    }
-
-    static std::string classname(){
-      return "Noop";
-    }
-  };
-
-} //namespace AlignmentPolicies
-} //namespace mallocMC
+    } // namespace AlignmentPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/alignmentPolicies/Shrink.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink.hpp
@@ -31,29 +31,32 @@
 
 #pragma once
 
-namespace mallocMC{
-namespace AlignmentPolicies{
+namespace mallocMC
+{
+    namespace AlignmentPolicies
+    {
+        namespace ShrinkConfig
+        {
+            struct DefaultShrinkConfig
+            {
+                static constexpr auto dataAlignment = 16;
+            };
+        } // namespace ShrinkConfig
 
-namespace ShrinkConfig{
-  struct DefaultShrinkConfig{
-    static constexpr auto dataAlignment = 16;
-  };
-} // namespace ShrinkConfig
+        /**
+         * @brief Provides proper alignment of pool and pads memory requests
+         *
+         * This AlignmentPolicy is based on ideas from ScatterAlloc
+         * (http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=6339604).
+         * It performs alignment operations on big memory pools and requests to
+         * allocate memory. Memory pools are truncated at the beginning until
+         * the pointer to the memory fits the alignment. Requests to allocate
+         * memory are padded until their size is a multiple of the alignment.
+         *
+         * @tparam T_Config (optional) The alignment to use
+         */
+        template<typename T_Config = ShrinkConfig::DefaultShrinkConfig>
+        class Shrink;
 
-  /**
-   * @brief Provides proper alignment of pool and pads memory requests
-   *
-   * This AlignmentPolicy is based on ideas from ScatterAlloc
-   * (http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=6339604). It
-   * performs alignment operations on big memory pools and requests to allocate
-   * memory. Memory pools are truncated at the beginning until the pointer to
-   * the memory fits the alignment. Requests to allocate memory are padded
-   * until their size is a multiple of the alignment.
-   *
-   * @tparam T_Config (optional) The alignment to use
-   */
-  template<typename T_Config = ShrinkConfig::DefaultShrinkConfig>
-  class Shrink;
-
-} //namespace AlignmentPolicies
-} //namespace mallocMC
+    } // namespace AlignmentPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -90,8 +90,8 @@ namespace mallocMC
                 "dataAlignment must also be a power of 2");
 
         public:
-            static auto
-            alignPool(void * memory, size_t memsize) -> std::tuple<void *, size_t>
+            static auto alignPool(void * memory, size_t memsize)
+                -> std::tuple<void *, size_t>
             {
                 PointerEquivalent alignmentstatus
                     = ((PointerEquivalent)memory) & (dataAlignment - 1);

--- a/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -90,8 +90,8 @@ namespace mallocMC
                 "dataAlignment must also be a power of 2");
 
         public:
-            static std::tuple<void *, size_t>
-            alignPool(void * memory, size_t memsize)
+            static auto
+            alignPool(void * memory, size_t memsize) -> std::tuple<void *, size_t>
             {
                 PointerEquivalent alignmentstatus
                     = ((PointerEquivalent)memory) & (dataAlignment - 1);
@@ -124,13 +124,13 @@ namespace mallocMC
 
             MAMC_HOST
             MAMC_ACCELERATOR
-            static uint32 applyPadding(uint32 bytes)
+            static auto applyPadding(uint32 bytes) -> uint32
             {
                 return (bytes + dataAlignment - 1) & ~(dataAlignment - 1);
             }
 
             MAMC_HOST
-            static std::string classname()
+            static auto classname() -> std::string
             {
                 std::stringstream ss;
                 ss << "Shrink[" << dataAlignment << "]";

--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -47,7 +47,8 @@ namespace mallocMC
         template<typename T_Allocator, bool T_providesAvailableSlots>
         struct GetAvailableSlotsIfAvailHost
         {
-            MAMC_HOST static auto getAvailableSlots(size_t, T_Allocator &) -> unsigned
+            MAMC_HOST static auto getAvailableSlots(size_t, T_Allocator &)
+                -> unsigned
             {
                 return 0;
             }
@@ -57,8 +58,8 @@ namespace mallocMC
         struct GetAvailableSlotsIfAvailHost<T_Allocator, true>
         {
             MAMC_HOST
-            static auto
-            getAvailableSlots(size_t slotSize, T_Allocator & alloc) -> unsigned
+            static auto getAvailableSlots(size_t slotSize, T_Allocator & alloc)
+                -> unsigned
             {
                 return T_Allocator::CreationPolicy::getAvailableSlotsHost(
                     slotSize, alloc.getAllocatorHandle().devAllocator);

--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -47,7 +47,7 @@ namespace mallocMC
         template<typename T_Allocator, bool T_providesAvailableSlots>
         struct GetAvailableSlotsIfAvailHost
         {
-            MAMC_HOST static unsigned getAvailableSlots(size_t, T_Allocator &)
+            MAMC_HOST static auto getAvailableSlots(size_t, T_Allocator &) -> unsigned
             {
                 return 0;
             }
@@ -57,8 +57,8 @@ namespace mallocMC
         struct GetAvailableSlotsIfAvailHost<T_Allocator, true>
         {
             MAMC_HOST
-            static unsigned
-            getAvailableSlots(size_t slotSize, T_Allocator & alloc)
+            static auto
+            getAvailableSlots(size_t slotSize, T_Allocator & alloc) -> unsigned
             {
                 return T_Allocator::CreationPolicy::getAvailableSlotsHost(
                     slotSize, alloc.getAllocatorHandle().devAllocator);
@@ -182,7 +182,7 @@ namespace mallocMC
         }
 
         MAMC_HOST
-        AllocatorHandle getAllocatorHandle()
+        auto getAllocatorHandle() -> AllocatorHandle
         {
             return allocatorHandle;
         }
@@ -193,7 +193,7 @@ namespace mallocMC
             return getAllocatorHandle();
         }
 
-        MAMC_HOST static std::string info(std::string linebreak = " ")
+        MAMC_HOST static auto info(std::string linebreak = " ") -> std::string
         {
             std::stringstream ss;
             ss << "CreationPolicy:      " << CreationPolicy::classname()
@@ -212,7 +212,7 @@ namespace mallocMC
         // polymorphism over the availability of getAvailableSlots for calling
         // from the host
         MAMC_HOST
-        unsigned getAvailableSlots(size_t slotSize)
+        auto getAvailableSlots(size_t slotSize) -> unsigned
         {
             slotSize = AlignmentPolicy::applyPadding(slotSize);
             return detail::GetAvailableSlotsIfAvailHost<
@@ -222,7 +222,7 @@ namespace mallocMC
         }
 
         MAMC_HOST
-        HeapInfoVector getHeapLocations()
+        auto getHeapLocations() -> HeapInfoVector
         {
             HeapInfoVector v;
             v.push_back(heapInfos);

--- a/src/include/mallocMC/allocator.hpp
+++ b/src/include/mallocMC/allocator.hpp
@@ -40,52 +40,44 @@
 #include <tuple>
 #include <vector>
 
-namespace mallocMC{
-namespace detail{
-
-    template<
-        typename T_Allocator,
-        bool T_providesAvailableSlots
-    >
-    struct GetAvailableSlotsIfAvailHost
+namespace mallocMC
+{
+    namespace detail
     {
-        MAMC_HOST static
-        unsigned
-        getAvailableSlots(
-            size_t,
-            T_Allocator &
-        )
+        template<typename T_Allocator, bool T_providesAvailableSlots>
+        struct GetAvailableSlotsIfAvailHost
         {
-            return 0;
-        }
-    };
+            MAMC_HOST static unsigned getAvailableSlots(size_t, T_Allocator &)
+            {
+                return 0;
+            }
+        };
 
-    template<class T_Allocator>
-    struct GetAvailableSlotsIfAvailHost<T_Allocator, true>
-    {
-        MAMC_HOST
-        static unsigned
-        getAvailableSlots(
-            size_t slotSize,
-            T_Allocator& alloc
-        ){
-            return T_Allocator::CreationPolicy::getAvailableSlotsHost(slotSize, alloc.getAllocatorHandle().devAllocator);
-        }
-    };
-}  // namespace detail
+        template<class T_Allocator>
+        struct GetAvailableSlotsIfAvailHost<T_Allocator, true>
+        {
+            MAMC_HOST
+            static unsigned
+            getAvailableSlots(size_t slotSize, T_Allocator & alloc)
+            {
+                return T_Allocator::CreationPolicy::getAvailableSlotsHost(
+                    slotSize, alloc.getAllocatorHandle().devAllocator);
+            }
+        };
+    } // namespace detail
 
     struct HeapInfo
     {
-        void* p;
+        void * p;
         size_t size;
     };
 
     /**
      * @brief "HostClass" that combines all policies to a useful allocator
      *
-     * This class implements the necessary glue-logic to form an actual allocator
-     * from the provided policies. It implements the public interface and
-     * executes some constraint checking based on an instance of the class
+     * This class implements the necessary glue-logic to form an actual
+     * allocator from the provided policies. It implements the public interface
+     * and executes some constraint checking based on an instance of the class
      * PolicyConstraints.
      *
      * @tparam T_CreationPolicy The desired type of a CreationPolicy
@@ -95,20 +87,18 @@ namespace detail{
      * @tparam T_AlignmentPolicy The desired type of a AlignmentPolicy
      */
     template<
-       typename T_CreationPolicy,
-       typename T_DistributionPolicy,
-       typename T_OOMPolicy,
-       typename T_ReservePoolPolicy,
-       typename T_AlignmentPolicy
-    >
+        typename T_CreationPolicy,
+        typename T_DistributionPolicy,
+        typename T_OOMPolicy,
+        typename T_ReservePoolPolicy,
+        typename T_AlignmentPolicy>
     class Allocator :
-        public PolicyConstraints<
-            T_CreationPolicy,
-            T_DistributionPolicy,
-            T_OOMPolicy,
-            T_ReservePoolPolicy,
-            T_AlignmentPolicy
-        >
+            public PolicyConstraints<
+                T_CreationPolicy,
+                T_DistributionPolicy,
+                T_OOMPolicy,
+                T_ReservePoolPolicy,
+                T_AlignmentPolicy>
     {
         using uint32 = std::uint32_t;
 
@@ -135,29 +125,13 @@ namespace detail{
          * @param size number of bytes
          */
         MAMC_HOST
-        void
-        alloc(
-            size_t size
-        )
+        void alloc(size_t size)
         {
-            void* pool = ReservePoolPolicy::setMemPool( size );
-            std::tie(
-                pool,
-                size
-            ) = AlignmentPolicy::alignPool(
-                pool,
-                size
-            );
-            DevAllocator* devAllocatorPtr;
-            cudaMalloc(
-                ( void** ) &devAllocatorPtr,
-                sizeof( DevAllocator )
-            );
-            CreationPolicy::initHeap(
-                devAllocatorPtr,
-                pool,
-                size
-            );
+            void * pool = ReservePoolPolicy::setMemPool(size);
+            std::tie(pool, size) = AlignmentPolicy::alignPool(pool, size);
+            DevAllocator * devAllocatorPtr;
+            cudaMalloc((void **)&devAllocatorPtr, sizeof(DevAllocator));
+            CreationPolicy::initHeap(devAllocatorPtr, pool, size);
 
             allocatorHandle.devAllocator = devAllocatorPtr;
             heapInfos.p = pool;
@@ -172,8 +146,8 @@ namespace detail{
         MAMC_HOST
         void free()
         {
-            cudaFree( allocatorHandle.devAllocator );
-            ReservePoolPolicy::resetMemPool( heapInfos.p );
+            cudaFree(allocatorHandle.devAllocator);
+            ReservePoolPolicy::resetMemPool(heapInfos.p);
             allocatorHandle.devAllocator = nullptr;
             heapInfos.size = 0;
             heapInfos.p = nullptr;
@@ -181,24 +155,19 @@ namespace detail{
 
         /* forbid to copy the allocator */
         MAMC_HOST
-        Allocator( const Allocator& );
+        Allocator(const Allocator &);
 
     public:
-
-
         MAMC_HOST
-        Allocator(
-            size_t size = 8U * 1024U * 1024U
-        ) :
-            allocatorHandle( nullptr )
+        Allocator(size_t size = 8U * 1024U * 1024U) : allocatorHandle(nullptr)
         {
-            alloc( size );
+            alloc(size);
         }
 
         MAMC_HOST
-        ~Allocator( )
+        ~Allocator()
         {
-            free( );
+            free();
         }
 
         /** destroy current heap data and resize the heap
@@ -206,18 +175,14 @@ namespace detail{
          * @param size number of bytes
          */
         MAMC_HOST
-        void
-        destructiveResize(
-            size_t size
-        )
+        void destructiveResize(size_t size)
         {
-            free( );
-            alloc( size );
+            free();
+            alloc(size);
         }
 
         MAMC_HOST
-        AllocatorHandle
-        getAllocatorHandle( )
+        AllocatorHandle getAllocatorHandle()
         {
             return allocatorHandle;
         }
@@ -228,45 +193,41 @@ namespace detail{
             return getAllocatorHandle();
         }
 
-        MAMC_HOST static
-        std::string
-        info(
-            std::string linebreak = " "
-        )
+        MAMC_HOST static std::string info(std::string linebreak = " ")
         {
             std::stringstream ss;
-            ss << "CreationPolicy:      " << CreationPolicy::classname( ) << "    " << linebreak;
-            ss << "DistributionPolicy:  " << DistributionPolicy::classname( ) << "" << linebreak;
-            ss << "OOMPolicy:           " << OOMPolicy::classname( ) << "         " << linebreak;
-            ss << "ReservePoolPolicy:   " << ReservePoolPolicy::classname( ) << " " << linebreak;
-            ss << "AlignmentPolicy:     " << AlignmentPolicy::classname( ) << "   " << linebreak;
+            ss << "CreationPolicy:      " << CreationPolicy::classname()
+               << "    " << linebreak;
+            ss << "DistributionPolicy:  " << DistributionPolicy::classname()
+               << "" << linebreak;
+            ss << "OOMPolicy:           " << OOMPolicy::classname()
+               << "         " << linebreak;
+            ss << "ReservePoolPolicy:   " << ReservePoolPolicy::classname()
+               << " " << linebreak;
+            ss << "AlignmentPolicy:     " << AlignmentPolicy::classname()
+               << "   " << linebreak;
             return ss.str();
         }
 
-        // polymorphism over the availability of getAvailableSlots for calling from the host
+        // polymorphism over the availability of getAvailableSlots for calling
+        // from the host
         MAMC_HOST
-        unsigned
-        getAvailableSlots(
-            size_t slotSize
-        )
+        unsigned getAvailableSlots(size_t slotSize)
         {
-            slotSize = AlignmentPolicy::applyPadding( slotSize );
+            slotSize = AlignmentPolicy::applyPadding(slotSize);
             return detail::GetAvailableSlotsIfAvailHost<
                 Allocator,
-                Traits<Allocator>::providesAvailableSlots
-            >::getAvailableSlots( slotSize, *this );
+                Traits<Allocator>::providesAvailableSlots>::
+                getAvailableSlots(slotSize, *this);
         }
 
         MAMC_HOST
-        HeapInfoVector
-        getHeapLocations( )
+        HeapInfoVector getHeapLocations()
         {
-          HeapInfoVector v;
-          v.push_back( heapInfos );
-          return v;
+            HeapInfoVector v;
+            v.push_back(heapInfos);
+            return v;
         }
-
     };
 
-} //namespace mallocMC
-
+} // namespace mallocMC

--- a/src/include/mallocMC/creationPolicies/OldMalloc.hpp
+++ b/src/include/mallocMC/creationPolicies/OldMalloc.hpp
@@ -27,18 +27,18 @@
 
 #pragma once
 
+namespace mallocMC
+{
+    namespace CreationPolicies
+    {
+        /**
+         * @brief classic malloc/free behaviour known from CUDA
+         *
+         * This CreationPolicy implements the classic device-side malloc and
+         * free system calls that is offered by CUDA-capable accelerator of
+         * compute capability 2.0 and higher
+         */
+        class OldMalloc;
 
-namespace mallocMC{
-namespace CreationPolicies{
-    
-  /**
-   * @brief classic malloc/free behaviour known from CUDA
-   *
-   * This CreationPolicy implements the classic device-side malloc and free
-   * system calls that is offered by CUDA-capable accelerator of compute
-   * capability 2.0 and higher
-   */
-  class OldMalloc;
-
-} //namespace CreationPolicies
-} //namespace mallocMC
+    } // namespace CreationPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
@@ -42,7 +42,7 @@ namespace mallocMC
         public:
             static constexpr auto providesAvailableSlots = false;
 
-            __device__ void * create(uint32 bytes) const
+            __device__ auto create(uint32 bytes) const -> void *
             {
                 return ::malloc(static_cast<size_t>(bytes));
             }
@@ -52,18 +52,18 @@ namespace mallocMC
                 ::free(mem);
             }
 
-            __device__ bool isOOM(void * p, size_t s) const
+            __device__ auto isOOM(void * p, size_t s) const -> bool
             {
                 return s != 0 && (p == nullptr);
             }
 
             template<typename T>
-            static void * initHeap(T * dAlloc, void *, size_t)
+            static auto initHeap(T * dAlloc, void *, size_t) -> void *
             {
                 return dAlloc;
             }
 
-            static std::string classname()
+            static auto classname() -> std::string
             {
                 return "OldMalloc";
             }

--- a/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
@@ -27,43 +27,47 @@
 
 #pragma once
 
-#include <cstdint>
-
 #include "OldMalloc.hpp"
 
-namespace mallocMC{
-namespace CreationPolicies{
+#include <cstdint>
 
-  class OldMalloc
-  {
-    using uint32 = std::uint32_t;
-
-    public:
-    static constexpr auto providesAvailableSlots = false;
-
-    __device__ void* create(uint32 bytes) const
+namespace mallocMC
+{
+    namespace CreationPolicies
     {
-      return ::malloc(static_cast<size_t>(bytes));
-    }
+        class OldMalloc
+        {
+            using uint32 = std::uint32_t;
 
-    __device__ void destroy(void* mem) const
-    {
-      ::free(mem);
-    }
+        public:
+            static constexpr auto providesAvailableSlots = false;
 
-    __device__ bool isOOM(void* p, size_t s) const {
-      return s != 0 && (p == nullptr);
-    }
+            __device__ void * create(uint32 bytes) const
+            {
+                return ::malloc(static_cast<size_t>(bytes));
+            }
 
-    template < typename T >
-    static void* initHeap(T* dAlloc, void*, size_t) {
-      return dAlloc;
-    }
+            __device__ void destroy(void * mem) const
+            {
+                ::free(mem);
+            }
 
-    static std::string classname() {
-      return "OldMalloc";
-    }
-  };
+            __device__ bool isOOM(void * p, size_t s) const
+            {
+                return s != 0 && (p == nullptr);
+            }
 
-} //namespace CreationPolicies
-} //namespace mallocMC
+            template<typename T>
+            static void * initHeap(T * dAlloc, void *, size_t)
+            {
+                return dAlloc;
+            }
+
+            static std::string classname()
+            {
+                return "OldMalloc";
+            }
+        };
+
+    } // namespace CreationPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -33,49 +33,52 @@
 
 #pragma once
 
-namespace mallocMC{
-namespace CreationPolicies{
-namespace ScatterConf{
-  struct DefaultScatterConfig{
-    static constexpr auto pagesize = 4096;
-    static constexpr auto accessblocks = 8;
-    static constexpr auto regionsize = 16;
-    static constexpr auto wastefactor = 2;
-    static constexpr auto resetfreedpages = false;
-  };
+namespace mallocMC
+{
+    namespace CreationPolicies
+    {
+        namespace ScatterConf
+        {
+            struct DefaultScatterConfig
+            {
+                static constexpr auto pagesize = 4096;
+                static constexpr auto accessblocks = 8;
+                static constexpr auto regionsize = 16;
+                static constexpr auto wastefactor = 2;
+                static constexpr auto resetfreedpages = false;
+            };
 
-  struct DefaultScatterHashingParams{
-    static constexpr auto hashingK = 38183;
-    static constexpr auto hashingDistMP = 17497;
-    static constexpr auto hashingDistWP = 1;
-    static constexpr auto hashingDistWPRel = 1;
-  };  
-}  // namespace ScatterConf
+            struct DefaultScatterHashingParams
+            {
+                static constexpr auto hashingK = 38183;
+                static constexpr auto hashingDistMP = 17497;
+                static constexpr auto hashingDistWP = 1;
+                static constexpr auto hashingDistWPRel = 1;
+            };
+        } // namespace ScatterConf
 
-  /**
-   * @brief fast memory allocation based on ScatterAlloc
-   *
-   * This CreationPolicy implements a fast memory allocator that trades speed
-   * for fragmentation of memory. This is based on the memory allocator
-   * "ScatterAlloc"
-   * (http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=6339604), and
-   * is extended to report free memory slots of a given size (both on host and
-   * accelerator).
-   * To work properly, this policy class requires a pre-allocated heap on the
-   * accelerator and works only with Nvidia CUDA capable accelerators that have
-   * at least compute capability 2.0.
-   *
-   * @tparam T_Config (optional) configure the heap layout. The
-   *        default can be obtained through Scatter<>::HeapProperties
-   * @tparam T_Hashing (optional) configure the parameters for
-   *        the hashing formula. The default can be obtained through
-   *        Scatter<>::HashingProperties
-   */
-  template<
-  class T_Config = ScatterConf::DefaultScatterConfig,
-  class T_Hashing = ScatterConf::DefaultScatterHashingParams
-  >
-  class Scatter;
+        /**
+         * @brief fast memory allocation based on ScatterAlloc
+         *
+         * This CreationPolicy implements a fast memory allocator that trades
+         * speed for fragmentation of memory. This is based on the memory
+         * allocator "ScatterAlloc"
+         * (http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=6339604),
+         * and is extended to report free memory slots of a given size (both on
+         * host and accelerator). To work properly, this policy class requires a
+         * pre-allocated heap on the accelerator and works only with Nvidia CUDA
+         * capable accelerators that have at least compute capability 2.0.
+         *
+         * @tparam T_Config (optional) configure the heap layout. The
+         *        default can be obtained through Scatter<>::HeapProperties
+         * @tparam T_Hashing (optional) configure the parameters for
+         *        the hashing formula. The default can be obtained through
+         *        Scatter<>::HashingProperties
+         */
+        template<
+            class T_Config = ScatterConf::DefaultScatterConfig,
+            class T_Hashing = ScatterConf::DefaultScatterHashingParams>
+        class Scatter;
 
-}// namespace CreationPolicies
-}// namespace mallocMC
+    } // namespace CreationPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -33,6 +33,9 @@
 
 #pragma once
 
+#include "../mallocMC_utils.hpp"
+#include "Scatter.hpp"
+
 #include <cassert>
 #include <cstdint> /* uint32_t */
 #include <cstdio>
@@ -40,48 +43,54 @@
 #include <stdexcept>
 #include <string>
 
-#include "../mallocMC_utils.hpp"
-#include "Scatter.hpp"
+namespace mallocMC
+{
+    namespace CreationPolicies
+    {
+        namespace ScatterKernelDetail
+        {
+            template<typename T_Allocator>
+            __global__ void
+            initKernel(T_Allocator * heap, void * heapmem, size_t memsize)
+            {
+                heap->pool = heapmem;
+                heap->initDeviceFunction(heapmem, memsize);
+            }
 
-namespace mallocMC{
-namespace CreationPolicies{
+            template<typename T_Allocator>
+            __global__ void getAvailableSlotsKernel(
+                T_Allocator * heap,
+                size_t slotSize,
+                unsigned * slots)
+            {
+                int gid = threadIdx.x + blockIdx.x * blockDim.x;
+                int nWorker = gridDim.x * blockDim.x;
+                unsigned temp = heap->getAvailaibleSlotsDeviceFunction(
+                    slotSize, gid, nWorker);
+                if(temp)
+                    atomicAdd(slots, temp);
+            }
 
-namespace ScatterKernelDetail{
-  template <typename T_Allocator>
-  __global__ void initKernel(T_Allocator* heap, void* heapmem, size_t memsize){
-    heap->pool = heapmem;
-    heap->initDeviceFunction(heapmem, memsize);
-  }
+            template<typename T_Allocator>
+            __global__ void finalizeKernel(T_Allocator * heap)
+            {
+                heap->finalizeDeviceFunction();
+            }
 
+        } // namespace ScatterKernelDetail
 
-  template < typename T_Allocator >
-  __global__ void getAvailableSlotsKernel(T_Allocator* heap, size_t slotSize, unsigned* slots){
-    int gid       = threadIdx.x + blockIdx.x*blockDim.x;
-    int nWorker   = gridDim.x * blockDim.x;
-    unsigned temp = heap->getAvailaibleSlotsDeviceFunction(slotSize, gid, nWorker);
-    if(temp) atomicAdd(slots, temp);
-  }
+        template<class T_Config, class T_Hashing>
+        class Scatter
+        {
+        public:
+            using HeapProperties = T_Config;
+            using HashingProperties = T_Hashing;
+            struct Properties : HeapProperties, HashingProperties
+            {};
+            static constexpr auto providesAvailableSlots = true;
 
-
-  template <typename T_Allocator>
-  __global__ void finalizeKernel(T_Allocator* heap){
-    heap->finalizeDeviceFunction();
-  }
-
-} //namespace ScatterKernelDetail
-
-  template<class T_Config, class T_Hashing>
-  class Scatter
-  {
-    public:
-      using HeapProperties = T_Config;
-      using HashingProperties = T_Hashing;
-      struct  Properties : HeapProperties, HashingProperties{};
-      static constexpr auto providesAvailableSlots = true;
-
-    private:
-      using uint32 = std::uint32_t;
-
+        private:
+            using uint32 = std::uint32_t;
 
 /** Allow for a hierarchical validation of parameters:
  *
@@ -95,872 +104,1074 @@ namespace ScatterKernelDetail{
 #ifndef MALLOCMC_CP_SCATTER_PAGESIZE
 #define MALLOCMC_CP_SCATTER_PAGESIZE (HeapProperties::pagesize)
 #endif
-      static constexpr uint32 pagesize      = MALLOCMC_CP_SCATTER_PAGESIZE;
+            static constexpr uint32 pagesize = MALLOCMC_CP_SCATTER_PAGESIZE;
 
 #ifndef MALLOCMC_CP_SCATTER_ACCESSBLOCKS
 #define MALLOCMC_CP_SCATTER_ACCESSBLOCKS (HeapProperties::accessblocks)
 #endif
-      static constexpr uint32 accessblocks  = MALLOCMC_CP_SCATTER_ACCESSBLOCKS;
+            static constexpr uint32 accessblocks
+                = MALLOCMC_CP_SCATTER_ACCESSBLOCKS;
 
 #ifndef MALLOCMC_CP_SCATTER_REGIONSIZE
 #define MALLOCMC_CP_SCATTER_REGIONSIZE (HeapProperties::regionsize)
 #endif
-      static constexpr uint32 regionsize    = MALLOCMC_CP_SCATTER_REGIONSIZE;
+            static constexpr uint32 regionsize = MALLOCMC_CP_SCATTER_REGIONSIZE;
 
 #ifndef MALLOCMC_CP_SCATTER_WASTEFACTOR
 #define MALLOCMC_CP_SCATTER_WASTEFACTOR (HeapProperties::wastefactor)
 #endif
-      static constexpr uint32 wastefactor   = MALLOCMC_CP_SCATTER_WASTEFACTOR;
+            static constexpr uint32 wastefactor
+                = MALLOCMC_CP_SCATTER_WASTEFACTOR;
 
 #ifndef MALLOCMC_CP_SCATTER_RESETFREEDPAGES
 #define MALLOCMC_CP_SCATTER_RESETFREEDPAGES (HeapProperties::resetfreedpages)
 #endif
-      static constexpr bool resetfreedpages = MALLOCMC_CP_SCATTER_RESETFREEDPAGES;
+            static constexpr bool resetfreedpages
+                = MALLOCMC_CP_SCATTER_RESETFREEDPAGES;
 
-    public:
-      static constexpr uint32 _pagesize       = pagesize;
-      static constexpr uint32 _accessblocks   = accessblocks;
-      static constexpr uint32 _regionsize     = regionsize;
-      static constexpr uint32 _wastefactor    = wastefactor;
-      static constexpr bool _resetfreedpages  = resetfreedpages;
+        public:
+            static constexpr uint32 _pagesize = pagesize;
+            static constexpr uint32 _accessblocks = accessblocks;
+            static constexpr uint32 _regionsize = regionsize;
+            static constexpr uint32 _wastefactor = wastefactor;
+            static constexpr bool _resetfreedpages = resetfreedpages;
 
-    private:
+        private:
 #if _DEBUG || ANALYSEHEAP
-    public:
+        public:
 #endif
-      //static constexpr uint32 minChunkSize0 = pagesize/(32*32);
-      static constexpr uint32 minChunkSize1 = 0x10;
-      static constexpr uint32 HierarchyThreshold =  (pagesize - 2*sizeof(uint32))/33;
-      static constexpr uint32 minSegmentSize = 32*minChunkSize1 + sizeof(uint32);
-      static constexpr uint32 tmp_maxOPM = minChunkSize1 > HierarchyThreshold ? 0 : (pagesize + (minSegmentSize-1)) / minSegmentSize;
-      static constexpr uint32 maxOnPageMasks = 32 > tmp_maxOPM ? tmp_maxOPM : 32;
+            // static constexpr uint32 minChunkSize0 = pagesize/(32*32);
+            static constexpr uint32 minChunkSize1 = 0x10;
+            static constexpr uint32 HierarchyThreshold
+                = (pagesize - 2 * sizeof(uint32)) / 33;
+            static constexpr uint32 minSegmentSize
+                = 32 * minChunkSize1 + sizeof(uint32);
+            static constexpr uint32 tmp_maxOPM
+                = minChunkSize1 > HierarchyThreshold
+                ? 0
+                : (pagesize + (minSegmentSize - 1)) / minSegmentSize;
+            static constexpr uint32 maxOnPageMasks
+                = 32 > tmp_maxOPM ? tmp_maxOPM : 32;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGK
 #define MALLOCMC_CP_SCATTER_HASHINGK (HashingProperties::hashingK)
 #endif
-     static constexpr uint32 hashingK       = MALLOCMC_CP_SCATTER_HASHINGK;
+            static constexpr uint32 hashingK = MALLOCMC_CP_SCATTER_HASHINGK;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTMP
 #define MALLOCMC_CP_SCATTER_HASHINGDISTMP (HashingProperties::hashingDistMP)
 #endif
-     static constexpr uint32 hashingDistMP  = MALLOCMC_CP_SCATTER_HASHINGDISTMP;
+            static constexpr uint32 hashingDistMP
+                = MALLOCMC_CP_SCATTER_HASHINGDISTMP;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTWP
 #define MALLOCMC_CP_SCATTER_HASHINGDISTWP (HashingProperties::hashingDistWP)
 #endif
-     static constexpr uint32 hashingDistWP  = MALLOCMC_CP_SCATTER_HASHINGDISTWP;
+            static constexpr uint32 hashingDistWP
+                = MALLOCMC_CP_SCATTER_HASHINGDISTWP;
 
 #ifndef MALLOCMC_CP_SCATTER_HASHINGDISTWPREL
-#define MALLOCMC_CP_SCATTER_HASHINGDISTWPREL (HashingProperties::hashingDistWPRel)
+#define MALLOCMC_CP_SCATTER_HASHINGDISTWPREL \
+    (HashingProperties::hashingDistWPRel)
 #endif
-     static constexpr uint32 hashingDistWPRel = MALLOCMC_CP_SCATTER_HASHINGDISTWPREL;
+            static constexpr uint32 hashingDistWPRel
+                = MALLOCMC_CP_SCATTER_HASHINGDISTWPREL;
 
-
-      /**
-       * Page Table Entry struct
-       * The PTE holds basic information about each page
-       */
-      struct PTE
-      {
-        uint32 chunksize;
-        uint32 count;
-        uint32 bitmask;
-
-        __device__ void init()
-        {
-          chunksize = 0;
-          count = 0;
-          bitmask = 0;
-        }
-      };
-
-      /**
-       * Page struct
-       * The page struct is used to access the data on the page more efficiently
-       * and to clear the area on the page, which might hold bitsfields later one
-       */
-      struct Page
-      {
-        char data[pagesize];
-
-        /**
-         * The pages init method
-         * This method initializes the region on the page which might hold
-         * bit fields when the page is used for a small chunk size
-         * @param previous_chunksize the chunksize which was uses for the page before
-         */
-        __device__ void init()
-        {
-          //clear the entire data which can hold bitfields
-          uint32* write = (uint32*)(data + pagesize - (int)(sizeof(uint32)*maxOnPageMasks));
-          while(write < (uint32*)(data + pagesize))
-            *write++ = 0;
-        }
-      };
-
-      // the data used by the allocator
-
-      volatile PTE* _ptes;
-      volatile uint32* _regions;
-      Page* _page;
-      uint32 _numpages;
-      size_t _memsize;
-      uint32 _pagebasedMutex;
-      volatile uint32 _firstFreePageBased;
-      volatile uint32 _firstfreeblock;
-
-
-      /**
-       * randInit should create an random offset which can be used
-       * as the initial position in a bitfield
-       */
-      static __device__ inline uint32 randInit()
-      {
-        //start with the laneid offset
-        return laneid();
-      }
-
-      /**
-       * randInextspot delivers the next free spot in a bitfield
-       * it searches for the next unset bit to the left of spot and
-       * returns its offset. if there are no unset bits to the left
-       * then it wraps around
-       * @param bitfield the bitfield to be searched for
-       * @param spot the spot from which to search to the left
-       * @param spots number of bits that can be used
-       * @return next free spot in the bitfield
-       */
-      static __device__ inline uint32 nextspot(uint32 bitfield, uint32 spot, uint32 spots)
-      {
-        //wrap around the bitfields from the current spot to the left
-        bitfield = ((bitfield >> (spot + 1)) | (bitfield << (spots - (spot + 1))))&((1<<spots)-1);
-        //compute the step from the current spot in the bitfield
-        const uint32 step = __ffs(~bitfield);
-        //and return the new spot
-        return (spot + step) % spots;
-      }
-
-
-      /**
-       * onPageMasksPosition returns a pointer to the beginning of the onpagemasks inside a page.
-       * @param page the page that holds the masks
-       * @param the number of hierarchical page tables (bitfields) that are used inside this mask.
-       * @return pointer to the first address inside the page that holds metadata bitfields.
-       */
-      __device__ inline uint32* onPageMasksPosition(uint32 page, uint32 nMasks){
-        return (uint32*)(_page[page].data + pagesize - (int)sizeof(uint32) * nMasks);
-      }
-
-      /**
-       * usespot marks finds one free spot in the bitfield, marks it and returns its offset
-       * @param bitfield pointer to the bitfield to use
-       * @param spots overall number of spots the bitfield is responsible for
-       * @return if there is a free spot it returns the spot'S offset, otherwise -1
-       */
-      static __device__ inline int usespot(uint32 *bitfield, uint32 spots)
-      {
-        //get first spot
-        uint32 spot = randInit() % spots;
-        for(;;)
-        {
-          const uint32 mask = 1 << spot;
-          const uint32 old = atomicOr(bitfield, mask);
-          if( (old & mask) == 0)
-            return spot;
-          // note: __popc(old) == spots should be sufficient,
-          //but if someone corrupts the memory we end up in an endless loop in here...
-          if(__popc(old) >= spots)
-            return -1;
-          spot = nextspot(old, spot, spots);
-        }
-      }
-
-
-      /**
-       * calcAdditionalChunks determines the number of chunks that are contained in the last segment of a hierarchical page
-       *
-       * The additional checks are necessary to ensure correct results for very large pages and small chunksizes
-       *
-       * @param fullsegments the number of segments that can be completely filled in a page. This may NEVER be bigger than 32!
-       * @param segmentsize the number of bytes that are contained in a completely filled segment (32 chunks)
-       * @param chunksize the chosen allocation size within the page
-       * @return the number of additional chunks that will not fit in one of the fullsegments. For any correct input, this number is smaller than 32
-       */
-      static __device__ inline uint32 calcAdditionalChunks(uint32 fullsegments, uint32 segmentsize, uint32 chunksize){
-        if(fullsegments != 32)
-          return max(0, (int)pagesize - (int)fullsegments*segmentsize - (int)sizeof(uint32)) / chunksize;
-        else
-          return 0;
-      }
-
-
-      /**
-       * addChunkHierarchy finds a free chunk on a page which uses bit fields on the page
-       * @param chunksize the chunksize of the page
-       * @param fullsegments the number of full segments on the page (a 32 bits on the page)
-       * @param additional_chunks the number of additional chunks in last segment (less than 32 bits on the page)
-       * @param page the page to use
-       * @return pointer to a free chunk on the page, 0 if we were unable to obtain a free chunk
-       */
-      __device__ inline void* addChunkHierarchy(uint32 chunksize, uint32 fullsegments, uint32 additional_chunks, uint32 page)
-      {
-        const uint32 segments = fullsegments + (additional_chunks > 0 ? 1 : 0);
-        uint32 spot = randInit() % segments;
-        const uint32 mask = _ptes[page].bitmask;
-        if((mask & (1 << spot)) != 0)
-          spot = nextspot(mask, spot, segments);
-        const uint32 tries = segments - __popc(mask);
-        uint32* onpagemasks = onPageMasksPosition(page,segments);
-        for(uint32 i = 0; i < tries; ++i)
-        {
-          const int hspot = usespot(&onpagemasks[spot], spot < fullsegments ? 32 : additional_chunks);
-          if(hspot != -1)
-            return _page[page].data + (32*spot + hspot)*chunksize;
-          atomicOr((uint32*)&_ptes[page].bitmask, 1 << spot);
-          spot = nextspot(mask, spot, segments);
-        }
-        return 0;
-      }
-
-      /**
-       * addChunkNoHierarchy finds a free chunk on a page which uses the bit fields of the pte only
-       * @param chunksize the chunksize of the page
-       * @param page the page to use
-       * @param spots the number of chunks which fit on the page
-       * @return pointer to a free chunk on the page, 0 if we were unable to obtain a free chunk
-       */
-      __device__ inline void* addChunkNoHierarchy(uint32 chunksize, uint32 page, uint32 spots)
-      {
-        const int spot = usespot((uint32*)&_ptes[page].bitmask, spots);
-        if(spot == -1)
-          return 0; //that should be impossible :)
-        return _page[page].data + spot*chunksize;
-      }
-
-      /**
-       * tryUsePage tries to use the page for the allocation request
-       * @param page the page to use
-       * @param chunksize the chunksize of the page
-       * @return pointer to a free chunk on the page, 0 if we were unable to obtain a free chunk
-       */
-      __device__ inline void* tryUsePage(uint32 page, uint32 chunksize)
-      {
-        void* chunk_ptr = nullptr;
-
-        //increse the fill level
-        const uint32 filllevel = atomicAdd((uint32*)&(_ptes[page].count), 1);
-        //recheck chunck size (it could be that the page got freed in the meanwhile...)
-        if(!resetfreedpages || _ptes[page].chunksize == chunksize)
-        {
-          if(chunksize <= HierarchyThreshold)
-          {
-            //more chunks than can be covered by the pte's single bitfield can be used
-            const uint32 segmentsize = chunksize*32 + sizeof(uint32);
-            const uint32 fullsegments = min(32,pagesize / segmentsize);
-            const uint32 additional_chunks = calcAdditionalChunks(fullsegments, segmentsize, chunksize);
-            if(filllevel < fullsegments * 32 + additional_chunks)
-              chunk_ptr = addChunkHierarchy(chunksize, fullsegments, additional_chunks, page);
-          }
-          else
-          {
-            const uint32 chunksinpage = min(pagesize / chunksize, 32);
-            if(filllevel < chunksinpage)
-              chunk_ptr = addChunkNoHierarchy(chunksize, page, chunksinpage);
-          }
-        }
-
-        //this one is full/not useable
-        if(chunk_ptr == nullptr)
-          atomicSub((uint32*)&(_ptes[page].count), 1);
-
-        return chunk_ptr;
-      }
-
-
-      /**
-       * allocChunked tries to allocate the demanded number of bytes on one of the pages
-       * @param bytes the number of bytes to allocate
-       * @return pointer to a free chunk on a page, 0 if we were unable to obtain a free chunk
-       */
-      __device__ void* allocChunked(uint32 bytes)
-      {
-        const uint32 pagesperblock = _numpages/accessblocks;
-        const uint32 reloff = warpSize*bytes / pagesize;
-        const uint32 startpage = (bytes*hashingK + hashingDistMP*smid() + (hashingDistWP+hashingDistWPRel*reloff)*warpid() ) % pagesperblock;
-        const uint32 maxchunksize = min(pagesize,wastefactor*bytes);
-        uint32 startblock = _firstfreeblock;
-        uint32 ptetry = startpage + startblock*pagesperblock;
-        uint32 checklevel = regionsize*3/4;
-        for(uint32 finder = 0; finder < 2; ++finder)
-        {
-          for(uint32 b = startblock; b < accessblocks; ++b)
-          {
-            while(ptetry < (b+1)*pagesperblock)
+            /**
+             * Page Table Entry struct
+             * The PTE holds basic information about each page
+             */
+            struct PTE
             {
-              const uint32 region = ptetry/regionsize;
-              const uint32 regionfilllevel = _regions[region];
-              if(regionfilllevel < checklevel )
-              {
-                for( ; ptetry < (region+1)*regionsize; ++ptetry)
+                uint32 chunksize;
+                uint32 count;
+                uint32 bitmask;
+
+                __device__ void init()
                 {
-                  const uint32 chunksize = _ptes[ptetry].chunksize;
-                  if(chunksize >= bytes && chunksize <= maxchunksize)
-                  {
-                    void * res = tryUsePage(ptetry, chunksize);
-                    if(res != 0)  return res;
-                  }
-                  else if(chunksize == 0)
-                  {
-                    //lets open up a new page
-                    //it is already padded
-                    const uint32 new_chunksize = max(bytes,minChunkSize1);
-                    const uint32 beforechunksize = atomicCAS((uint32*)&_ptes[ptetry].chunksize, 0, new_chunksize);
-                    if(beforechunksize == 0)
-                    {
-                      void * res = tryUsePage(ptetry, new_chunksize);
-                      if(res != 0)  return res;
-                    }
-                    else if(beforechunksize >= bytes &&  beforechunksize <= maxchunksize)
-                    {
-                      //someone else aquired the page, but we can also use it
-                      void * res = tryUsePage(ptetry, beforechunksize);
-                      if(res != 0)  return res;
-                    }
-                  }
+                    chunksize = 0;
+                    count = 0;
+                    bitmask = 0;
                 }
-                //could not alloc in region, tell that
-                if(regionfilllevel + 1 <= regionsize)
-                  atomicMax((uint32*)(_regions + region), regionfilllevel+1);
-              }
-              else
-                ptetry += regionsize;
-              //ptetry = (region+1)*regionsize;
-            }
-            //randomize the thread writing the info
-            //if(warpid() + laneid() == 0)
-            if(b > startblock)
-              _firstfreeblock = b;
-          }
+            };
 
-          //we are really full :/ so lets search every page for a spot!
-          startblock = 0;
-          checklevel = regionsize + 1;
-          ptetry = 0;
-        }
-        return 0;
-      }
-
-
-      /**
-       * deallocChunked frees the chunk on the page and updates all data accordingly
-       * @param mem pointer to the chunk
-       * @param page the page the chunk is on
-       * @param chunksize the chunksize used for the page
-       */
-      __device__ void deallocChunked(void* mem, uint32 page, uint32 chunksize)
-      {
-        const uint32 inpage_offset = ((char*)mem - _page[page].data);
-        if(chunksize <= HierarchyThreshold)
-        {
-          //one more level in hierarchy
-          const uint32 segmentsize = chunksize*32 + sizeof(uint32);
-          const uint32 fullsegments = min(32,pagesize / segmentsize);
-          const uint32 additional_chunks = calcAdditionalChunks(fullsegments,segmentsize,chunksize);
-          const uint32 segment = inpage_offset / (chunksize*32);
-          const uint32 withinsegment = (inpage_offset - segment*(chunksize*32))/chunksize;
-          //mark it as free
-          const uint32 nMasks = fullsegments + (additional_chunks > 0 ? 1 : 0);
-          uint32* onpagemasks = onPageMasksPosition(page,nMasks);
-          uint32 old = atomicAnd(&onpagemasks[segment], ~(1 << withinsegment));
-
-          // always do this, since it might fail due to a race-condition with addChunkHierarchy
-          atomicAnd((uint32*)&_ptes[page].bitmask, ~(1 << segment));
-        }
-        else
-        {
-          const uint32 segment = inpage_offset / chunksize;
-          atomicAnd((uint32*)&_ptes[page].bitmask, ~(1 << segment));
-        }
-        //reduce filllevel as free
-        const uint32 oldfilllevel = atomicSub((uint32*)&_ptes[page].count, 1);
-
-        if(resetfreedpages)
-        {
-          if(oldfilllevel == 1)
-          {
-            //this page now got free!
-            // -> try lock it
-            const uint32 old = atomicCAS((uint32*)&_ptes[page].count, 0, pagesize);
-            if(old == 0)
+            /**
+             * Page struct
+             * The page struct is used to access the data on the page more
+             * efficiently and to clear the area on the page, which might hold
+             * bitsfields later one
+             */
+            struct Page
             {
-              //clean the bits for the hierarchy
-              _page[page].init();
-              //remove chunk information
-              _ptes[page].chunksize = 0;
-              __threadfence();
-              //unlock it
-              atomicSub((uint32*)&_ptes[page].count, pagesize);
-            }
-          }
-        }
+                char data[pagesize];
 
-        //meta information counters ... should not be changed by too many threads, so..
-        if(oldfilllevel == pagesize / 2 / chunksize)
-        {
-          const uint32 region = page / regionsize;
-          _regions[region] = 0;
-          const uint32 block = region * regionsize * accessblocks / _numpages ;
-          if(warpid() + laneid() == 0)
-            atomicMin((uint32*)&_firstfreeblock, block);
-        }
-      }
+                /**
+                 * The pages init method
+                 * This method initializes the region on the page which might
+                 * hold bit fields when the page is used for a small chunk size
+                 * @param previous_chunksize the chunksize which was uses for
+                 * the page before
+                 */
+                __device__ void init()
+                {
+                    // clear the entire data which can hold bitfields
+                    uint32 * write
+                        = (uint32 *)(data + pagesize - (int)(sizeof(uint32) * maxOnPageMasks));
+                    while(write < (uint32 *)(data + pagesize)) *write++ = 0;
+                }
+            };
 
-      /**
-       * markpages markes a fixed number of pages as used
-       * @param startpage first page to mark
-       * @param pages number of pages to mark
-       * @param bytes number of overall bytes to mark pages for
-       * @return true on success, false if one of the pages is not free
-       */
-      __device__ bool markpages(uint32 startpage, uint32 pages, uint32 bytes)
-      {
-        int abord = -1;
-        for(uint32 trypage = startpage; trypage < startpage + pages; ++trypage)
-        {
-          const uint32 old = atomicCAS((uint32*)&_ptes[trypage].chunksize, 0, bytes);
-          if(old != 0)
-          {
-            abord = trypage;
-            break;
-          }
-        }
-        if(abord == -1)
-          return true;
-        for(uint32 trypage = startpage; trypage < abord; ++trypage)
-          atomicCAS((uint32*)&_ptes[trypage].chunksize, bytes, 0);
-        return false;
-      }
+            // the data used by the allocator
 
-      /**
-       * allocPageBasedSingleRegion tries to allocate the demanded number of bytes on a continues sequence of pages
-       * @param startpage first page to be used
-       * @param endpage last page to be used
-       * @param bytes number of overall bytes to mark pages for
-       * @return pointer to the first page to use, 0 if we were unable to use all the requested pages
-       */
-      __device__ void* allocPageBasedSingleRegion(uint32 startpage, uint32 endpage, uint32 bytes)
-      {
-        const uint32 pagestoalloc = divup(bytes, pagesize);
-        uint32 freecount = 0;
-        bool left_free = false;
-        for(uint32 search_page = startpage+1; search_page > endpage; )
-        {
-          --search_page;
-          if(_ptes[search_page].chunksize == 0)
-          {
-            if(++freecount == pagestoalloc)
+            volatile PTE * _ptes;
+            volatile uint32 * _regions;
+            Page * _page;
+            uint32 _numpages;
+            size_t _memsize;
+            uint32 _pagebasedMutex;
+            volatile uint32 _firstFreePageBased;
+            volatile uint32 _firstfreeblock;
+
+            /**
+             * randInit should create an random offset which can be used
+             * as the initial position in a bitfield
+             */
+            static __device__ inline uint32 randInit()
             {
-              //try filling it up
-              if(markpages(search_page, pagestoalloc, bytes))
-              {
-                //mark that we filled up everything up to here
-                if(!left_free)
-                  atomicCAS((uint32*)&_firstFreePageBased, startpage, search_page - 1);
-                return _page[search_page].data;
-              }
+                // start with the laneid offset
+                return laneid();
             }
-          }
-          else
-          {
-            left_free = true;
-            freecount = 0;
-          }
-        }
-        return 0;
-      }
 
-      /**
-       * allocPageBasedSingle tries to allocate the demanded number of bytes on a continues sequence of pages
-       * @param bytes number of overall bytes to mark pages for
-       * @return pointer to the first page to use, 0 if we were unable to use all the requested pages
-       * @pre only a single thread of a warp is allowed to call the function concurrently
-       */
-      __device__ void* allocPageBasedSingle(uint32 bytes)
-      {
-        //acquire mutex
-        while(atomicExch(&_pagebasedMutex,1) != 0);
-        //search for free spot from the back
-        const uint32 spage = _firstFreePageBased;
-        void* res = allocPageBasedSingleRegion(spage, 0, bytes);
-        if(res == 0)
-          //also check the rest of the pages
-          res = allocPageBasedSingleRegion(_numpages, spage, bytes);
+            /**
+             * randInextspot delivers the next free spot in a bitfield
+             * it searches for the next unset bit to the left of spot and
+             * returns its offset. if there are no unset bits to the left
+             * then it wraps around
+             * @param bitfield the bitfield to be searched for
+             * @param spot the spot from which to search to the left
+             * @param spots number of bits that can be used
+             * @return next free spot in the bitfield
+             */
+            static __device__ inline uint32
+            nextspot(uint32 bitfield, uint32 spot, uint32 spots)
+            {
+                // wrap around the bitfields from the current spot to the left
+                bitfield = ((bitfield >> (spot + 1))
+                            | (bitfield << (spots - (spot + 1))))
+                    & ((1 << spots) - 1);
+                // compute the step from the current spot in the bitfield
+                const uint32 step = __ffs(~bitfield);
+                // and return the new spot
+                return (spot + step) % spots;
+            }
 
-        //free mutex
-        atomicExch(&_pagebasedMutex,0);
-        return res;
-      }
-      /**
-       * allocPageBased tries to allocate the demanded number of bytes on a continues sequence of pages
-       * @param bytes number of overall bytes to mark pages for
-       * @return pointer to the first page to use, 0 if we were unable to use all the requested pages
-       */
-      __device__ void* allocPageBased(uint32 bytes)
-      {
-        //this is rather slow, but we dont expect that to happen often anyway
+            /**
+             * onPageMasksPosition returns a pointer to the beginning of the
+             * onpagemasks inside a page.
+             * @param page the page that holds the masks
+             * @param the number of hierarchical page tables (bitfields) that
+             * are used inside this mask.
+             * @return pointer to the first address inside the page that holds
+             * metadata bitfields.
+             */
+            __device__ inline uint32 *
+            onPageMasksPosition(uint32 page, uint32 nMasks)
+            {
+                return (
+                    uint32 *)(_page[page].data + pagesize - (int)sizeof(uint32) * nMasks);
+            }
 
-        //only one thread per warp can acquire the mutex
-        void* res = 0;
+            /**
+             * usespot marks finds one free spot in the bitfield, marks it and
+             * returns its offset
+             * @param bitfield pointer to the bitfield to use
+             * @param spots overall number of spots the bitfield is responsible
+             * for
+             * @return if there is a free spot it returns the spot'S offset,
+             * otherwise -1
+             */
+            static __device__ inline int
+            usespot(uint32 * bitfield, uint32 spots)
+            {
+                // get first spot
+                uint32 spot = randInit() % spots;
+                for(;;)
+                {
+                    const uint32 mask = 1 << spot;
+                    const uint32 old = atomicOr(bitfield, mask);
+                    if((old & mask) == 0)
+                        return spot;
+                    // note: __popc(old) == spots should be sufficient,
+                    // but if someone corrupts the memory we end up in an
+                    // endless loop in here...
+                    if(__popc(old) >= spots)
+                        return -1;
+                    spot = nextspot(old, spot, spots);
+                }
+            }
+
+            /**
+             * calcAdditionalChunks determines the number of chunks that are
+             * contained in the last segment of a hierarchical page
+             *
+             * The additional checks are necessary to ensure correct results for
+             * very large pages and small chunksizes
+             *
+             * @param fullsegments the number of segments that can be completely
+             * filled in a page. This may NEVER be bigger than 32!
+             * @param segmentsize the number of bytes that are contained in a
+             * completely filled segment (32 chunks)
+             * @param chunksize the chosen allocation size within the page
+             * @return the number of additional chunks that will not fit in one
+             * of the fullsegments. For any correct input, this number is
+             * smaller than 32
+             */
+            static __device__ inline uint32 calcAdditionalChunks(
+                uint32 fullsegments,
+                uint32 segmentsize,
+                uint32 chunksize)
+            {
+                if(fullsegments != 32)
+                    return max(0,
+                               (int)pagesize - (int)fullsegments * segmentsize
+                                   - (int)sizeof(uint32))
+                        / chunksize;
+                else
+                    return 0;
+            }
+
+            /**
+             * addChunkHierarchy finds a free chunk on a page which uses bit
+             * fields on the page
+             * @param chunksize the chunksize of the page
+             * @param fullsegments the number of full segments on the page (a 32
+             * bits on the page)
+             * @param additional_chunks the number of additional chunks in last
+             * segment (less than 32 bits on the page)
+             * @param page the page to use
+             * @return pointer to a free chunk on the page, 0 if we were unable
+             * to obtain a free chunk
+             */
+            __device__ inline void * addChunkHierarchy(
+                uint32 chunksize,
+                uint32 fullsegments,
+                uint32 additional_chunks,
+                uint32 page)
+            {
+                const uint32 segments
+                    = fullsegments + (additional_chunks > 0 ? 1 : 0);
+                uint32 spot = randInit() % segments;
+                const uint32 mask = _ptes[page].bitmask;
+                if((mask & (1 << spot)) != 0)
+                    spot = nextspot(mask, spot, segments);
+                const uint32 tries = segments - __popc(mask);
+                uint32 * onpagemasks = onPageMasksPosition(page, segments);
+                for(uint32 i = 0; i < tries; ++i)
+                {
+                    const int hspot = usespot(
+                        &onpagemasks[spot],
+                        spot < fullsegments ? 32 : additional_chunks);
+                    if(hspot != -1)
+                        return _page[page].data
+                            + (32 * spot + hspot) * chunksize;
+                    atomicOr((uint32 *)&_ptes[page].bitmask, 1 << spot);
+                    spot = nextspot(mask, spot, segments);
+                }
+                return 0;
+            }
+
+            /**
+             * addChunkNoHierarchy finds a free chunk on a page which uses the
+             * bit fields of the pte only
+             * @param chunksize the chunksize of the page
+             * @param page the page to use
+             * @param spots the number of chunks which fit on the page
+             * @return pointer to a free chunk on the page, 0 if we were unable
+             * to obtain a free chunk
+             */
+            __device__ inline void *
+            addChunkNoHierarchy(uint32 chunksize, uint32 page, uint32 spots)
+            {
+                const int spot = usespot((uint32 *)&_ptes[page].bitmask, spots);
+                if(spot == -1)
+                    return 0; // that should be impossible :)
+                return _page[page].data + spot * chunksize;
+            }
+
+            /**
+             * tryUsePage tries to use the page for the allocation request
+             * @param page the page to use
+             * @param chunksize the chunksize of the page
+             * @return pointer to a free chunk on the page, 0 if we were unable
+             * to obtain a free chunk
+             */
+            __device__ inline void * tryUsePage(uint32 page, uint32 chunksize)
+            {
+                void * chunk_ptr = nullptr;
+
+                // increse the fill level
+                const uint32 filllevel
+                    = atomicAdd((uint32 *)&(_ptes[page].count), 1);
+                // recheck chunck size (it could be that the page got freed in
+                // the meanwhile...)
+                if(!resetfreedpages || _ptes[page].chunksize == chunksize)
+                {
+                    if(chunksize <= HierarchyThreshold)
+                    {
+                        // more chunks than can be covered by the pte's single
+                        // bitfield can be used
+                        const uint32 segmentsize
+                            = chunksize * 32 + sizeof(uint32);
+                        const uint32 fullsegments
+                            = min(32, pagesize / segmentsize);
+                        const uint32 additional_chunks = calcAdditionalChunks(
+                            fullsegments, segmentsize, chunksize);
+                        if(filllevel < fullsegments * 32 + additional_chunks)
+                            chunk_ptr = addChunkHierarchy(
+                                chunksize,
+                                fullsegments,
+                                additional_chunks,
+                                page);
+                    }
+                    else
+                    {
+                        const uint32 chunksinpage
+                            = min(pagesize / chunksize, 32);
+                        if(filllevel < chunksinpage)
+                            chunk_ptr = addChunkNoHierarchy(
+                                chunksize, page, chunksinpage);
+                    }
+                }
+
+                // this one is full/not useable
+                if(chunk_ptr == nullptr)
+                    atomicSub((uint32 *)&(_ptes[page].count), 1);
+
+                return chunk_ptr;
+            }
+
+            /**
+             * allocChunked tries to allocate the demanded number of bytes on
+             * one of the pages
+             * @param bytes the number of bytes to allocate
+             * @return pointer to a free chunk on a page, 0 if we were unable to
+             * obtain a free chunk
+             */
+            __device__ void * allocChunked(uint32 bytes)
+            {
+                const uint32 pagesperblock = _numpages / accessblocks;
+                const uint32 reloff = warpSize * bytes / pagesize;
+                const uint32 startpage
+                    = (bytes * hashingK + hashingDistMP * smid()
+                       + (hashingDistWP + hashingDistWPRel * reloff) * warpid())
+                    % pagesperblock;
+                const uint32 maxchunksize = min(pagesize, wastefactor * bytes);
+                uint32 startblock = _firstfreeblock;
+                uint32 ptetry = startpage + startblock * pagesperblock;
+                uint32 checklevel = regionsize * 3 / 4;
+                for(uint32 finder = 0; finder < 2; ++finder)
+                {
+                    for(uint32 b = startblock; b < accessblocks; ++b)
+                    {
+                        while(ptetry < (b + 1) * pagesperblock)
+                        {
+                            const uint32 region = ptetry / regionsize;
+                            const uint32 regionfilllevel = _regions[region];
+                            if(regionfilllevel < checklevel)
+                            {
+                                for(; ptetry < (region + 1) * regionsize;
+                                    ++ptetry)
+                                {
+                                    const uint32 chunksize
+                                        = _ptes[ptetry].chunksize;
+                                    if(chunksize >= bytes
+                                       && chunksize <= maxchunksize)
+                                    {
+                                        void * res
+                                            = tryUsePage(ptetry, chunksize);
+                                        if(res != 0)
+                                            return res;
+                                    }
+                                    else if(chunksize == 0)
+                                    {
+                                        // lets open up a new page
+                                        // it is already padded
+                                        const uint32 new_chunksize
+                                            = max(bytes, minChunkSize1);
+                                        const uint32 beforechunksize
+                                            = atomicCAS(
+                                                (uint32 *)&_ptes[ptetry]
+                                                    .chunksize,
+                                                0,
+                                                new_chunksize);
+                                        if(beforechunksize == 0)
+                                        {
+                                            void * res = tryUsePage(
+                                                ptetry, new_chunksize);
+                                            if(res != 0)
+                                                return res;
+                                        }
+                                        else if(
+                                            beforechunksize >= bytes
+                                            && beforechunksize <= maxchunksize)
+                                        {
+                                            // someone else aquired the page,
+                                            // but we can also use it
+                                            void * res = tryUsePage(
+                                                ptetry, beforechunksize);
+                                            if(res != 0)
+                                                return res;
+                                        }
+                                    }
+                                }
+                                // could not alloc in region, tell that
+                                if(regionfilllevel + 1 <= regionsize)
+                                    atomicMax(
+                                        (uint32 *)(_regions + region),
+                                        regionfilllevel + 1);
+                            }
+                            else
+                                ptetry += regionsize;
+                            // ptetry = (region+1)*regionsize;
+                        }
+                        // randomize the thread writing the info
+                        // if(warpid() + laneid() == 0)
+                        if(b > startblock)
+                            _firstfreeblock = b;
+                    }
+
+                    // we are really full :/ so lets search every page for a
+                    // spot!
+                    startblock = 0;
+                    checklevel = regionsize + 1;
+                    ptetry = 0;
+                }
+                return 0;
+            }
+
+            /**
+             * deallocChunked frees the chunk on the page and updates all data
+             * accordingly
+             * @param mem pointer to the chunk
+             * @param page the page the chunk is on
+             * @param chunksize the chunksize used for the page
+             */
+            __device__ void
+            deallocChunked(void * mem, uint32 page, uint32 chunksize)
+            {
+                const uint32 inpage_offset = ((char *)mem - _page[page].data);
+                if(chunksize <= HierarchyThreshold)
+                {
+                    // one more level in hierarchy
+                    const uint32 segmentsize = chunksize * 32 + sizeof(uint32);
+                    const uint32 fullsegments = min(32, pagesize / segmentsize);
+                    const uint32 additional_chunks = calcAdditionalChunks(
+                        fullsegments, segmentsize, chunksize);
+                    const uint32 segment = inpage_offset / (chunksize * 32);
+                    const uint32 withinsegment
+                        = (inpage_offset - segment * (chunksize * 32))
+                        / chunksize;
+                    // mark it as free
+                    const uint32 nMasks
+                        = fullsegments + (additional_chunks > 0 ? 1 : 0);
+                    uint32 * onpagemasks = onPageMasksPosition(page, nMasks);
+                    uint32 old = atomicAnd(
+                        &onpagemasks[segment], ~(1 << withinsegment));
+
+                    // always do this, since it might fail due to a
+                    // race-condition with addChunkHierarchy
+                    atomicAnd((uint32 *)&_ptes[page].bitmask, ~(1 << segment));
+                }
+                else
+                {
+                    const uint32 segment = inpage_offset / chunksize;
+                    atomicAnd((uint32 *)&_ptes[page].bitmask, ~(1 << segment));
+                }
+                // reduce filllevel as free
+                const uint32 oldfilllevel
+                    = atomicSub((uint32 *)&_ptes[page].count, 1);
+
+                if(resetfreedpages)
+                {
+                    if(oldfilllevel == 1)
+                    {
+                        // this page now got free!
+                        // -> try lock it
+                        const uint32 old = atomicCAS(
+                            (uint32 *)&_ptes[page].count, 0, pagesize);
+                        if(old == 0)
+                        {
+                            // clean the bits for the hierarchy
+                            _page[page].init();
+                            // remove chunk information
+                            _ptes[page].chunksize = 0;
+                            __threadfence();
+                            // unlock it
+                            atomicSub((uint32 *)&_ptes[page].count, pagesize);
+                        }
+                    }
+                }
+
+                // meta information counters ... should not be changed by too
+                // many threads, so..
+                if(oldfilllevel == pagesize / 2 / chunksize)
+                {
+                    const uint32 region = page / regionsize;
+                    _regions[region] = 0;
+                    const uint32 block
+                        = region * regionsize * accessblocks / _numpages;
+                    if(warpid() + laneid() == 0)
+                        atomicMin((uint32 *)&_firstfreeblock, block);
+                }
+            }
+
+            /**
+             * markpages markes a fixed number of pages as used
+             * @param startpage first page to mark
+             * @param pages number of pages to mark
+             * @param bytes number of overall bytes to mark pages for
+             * @return true on success, false if one of the pages is not free
+             */
+            __device__ bool
+            markpages(uint32 startpage, uint32 pages, uint32 bytes)
+            {
+                int abord = -1;
+                for(uint32 trypage = startpage; trypage < startpage + pages;
+                    ++trypage)
+                {
+                    const uint32 old = atomicCAS(
+                        (uint32 *)&_ptes[trypage].chunksize, 0, bytes);
+                    if(old != 0)
+                    {
+                        abord = trypage;
+                        break;
+                    }
+                }
+                if(abord == -1)
+                    return true;
+                for(uint32 trypage = startpage; trypage < abord; ++trypage)
+                    atomicCAS((uint32 *)&_ptes[trypage].chunksize, bytes, 0);
+                return false;
+            }
+
+            /**
+             * allocPageBasedSingleRegion tries to allocate the demanded number
+             * of bytes on a continues sequence of pages
+             * @param startpage first page to be used
+             * @param endpage last page to be used
+             * @param bytes number of overall bytes to mark pages for
+             * @return pointer to the first page to use, 0 if we were unable to
+             * use all the requested pages
+             */
+            __device__ void * allocPageBasedSingleRegion(
+                uint32 startpage,
+                uint32 endpage,
+                uint32 bytes)
+            {
+                const uint32 pagestoalloc = divup(bytes, pagesize);
+                uint32 freecount = 0;
+                bool left_free = false;
+                for(uint32 search_page = startpage + 1; search_page > endpage;)
+                {
+                    --search_page;
+                    if(_ptes[search_page].chunksize == 0)
+                    {
+                        if(++freecount == pagestoalloc)
+                        {
+                            // try filling it up
+                            if(markpages(search_page, pagestoalloc, bytes))
+                            {
+                                // mark that we filled up everything up to here
+                                if(!left_free)
+                                    atomicCAS(
+                                        (uint32 *)&_firstFreePageBased,
+                                        startpage,
+                                        search_page - 1);
+                                return _page[search_page].data;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        left_free = true;
+                        freecount = 0;
+                    }
+                }
+                return 0;
+            }
+
+            /**
+             * allocPageBasedSingle tries to allocate the demanded number of
+             * bytes on a continues sequence of pages
+             * @param bytes number of overall bytes to mark pages for
+             * @return pointer to the first page to use, 0 if we were unable to
+             * use all the requested pages
+             * @pre only a single thread of a warp is allowed to call the
+             * function concurrently
+             */
+            __device__ void * allocPageBasedSingle(uint32 bytes)
+            {
+                // acquire mutex
+                while(atomicExch(&_pagebasedMutex, 1) != 0)
+                    ;
+                // search for free spot from the back
+                const uint32 spage = _firstFreePageBased;
+                void * res = allocPageBasedSingleRegion(spage, 0, bytes);
+                if(res == 0)
+                    // also check the rest of the pages
+                    res = allocPageBasedSingleRegion(_numpages, spage, bytes);
+
+                // free mutex
+                atomicExch(&_pagebasedMutex, 0);
+                return res;
+            }
+            /**
+             * allocPageBased tries to allocate the demanded number of bytes on
+             * a continues sequence of pages
+             * @param bytes number of overall bytes to mark pages for
+             * @return pointer to the first page to use, 0 if we were unable to
+             * use all the requested pages
+             */
+            __device__ void * allocPageBased(uint32 bytes)
+            {
+                // this is rather slow, but we dont expect that to happen often
+                // anyway
+
+                // only one thread per warp can acquire the mutex
+                void * res = 0;
 #if(__CUDACC_VER_MAJOR__ >= 9)
-        const unsigned int mask = __activemask();
+                const unsigned int mask = __activemask();
 #else
-        const unsigned int mask = __ballot(1);
+                const unsigned int mask = __ballot(1);
 #endif
-        const unsigned int num = __popc(mask);
-        const unsigned int lanemask = mallocMC::lanemask_lt();
-        const unsigned int local_id = __popc(lanemask & mask);
-        for(unsigned int active = 0; active < num; ++active)
-          if (active == local_id)
-            res = allocPageBasedSingle(bytes);
-        return res;
-      }
-
-      /**
-       * deallocPageBased frees the memory placed on a sequence of pages
-       * @param mem pointer to the first page
-       * @param page the first page
-       * @param bytes the number of bytes to be freed
-       */
-      __device__ void deallocPageBased(void* mem, uint32 page, uint32 bytes)
-      {
-        const uint32 pages = divup(bytes,pagesize);
-        for(uint32 p = page; p < page+pages; ++p)
-          _page[p].init();
-        __threadfence();
-        for(uint32 p = page; p < page+pages; ++p)
-          atomicCAS((uint32*)&_ptes[p].chunksize, bytes, 0);
-        atomicMax((uint32*)&_firstFreePageBased, page+pages-1);
-      }
-
-
-    public:
-      /**
-       * create allocates the requested number of bytes via the heap. Coalescing has to be done before by another policy.
-       * @param bytes number of bytes to allocate
-       * @return pointer to the allocated memory
-       */
-      __device__ void* create(uint32 bytes)
-      {
-        if(bytes == 0)
-          return 0;
-        //take care of padding
-        //bytes = (bytes + dataAlignment - 1) & ~(dataAlignment-1); // in alignment-policy
-        if(bytes < pagesize)
-          //chunck based
-          return allocChunked(bytes);
-        else
-          //allocate a range of pages
-          return allocPageBased(bytes);
-      }
-
-      /**
-       * destroy frees the memory regions previously acllocted via create
-       * @param mempointer to the memory region to free
-       */
-      __device__ void destroy(void* mem)
-      {
-        if(mem == 0)
-          return;
-        //lets see on which page we are on
-        const uint32 page = ((char*)mem - (char*)_page)/pagesize;
-        const uint32 chunksize = _ptes[page].chunksize;
-
-        //is the pointer the beginning of a chunk?
-        const uint32 inpage_offset = ((char*)mem - _page[page].data);
-        const uint32 block = inpage_offset/chunksize;
-        const uint32 inblockoffset = inpage_offset - block*chunksize;
-        if(inblockoffset != 0)
-        {
-          uint32* counter = (uint32*)(_page[page].data + block*chunksize);
-          //coalesced mem free
-          uint32 old = atomicSub(counter, 1);
-          if(old != 1)
-            return;
-          mem = (void*) counter;
-        }
-
-        if(chunksize < pagesize)
-          deallocChunked(mem, page, chunksize);
-        else
-          deallocPageBased(mem, page, chunksize);
-      }
-
-      /**
-       * init inits the heap data structures
-       * the init method must be called before the heap can be used. the method can be called
-       * with an arbitrary number of threads, which will increase the inits efficiency
-       * @param memory pointer to the memory used for the heap
-       * @param memsize size of the memory in bytes
-       */
-      __device__ void initDeviceFunction(void* memory, size_t memsize)
-      {
-        uint32 linid = threadIdx.x + blockDim.x*(threadIdx.y + threadIdx.z*blockDim.y);
-        uint32 threads = blockDim.x*blockDim.y*blockDim.z;
-        const uint32 linblockid = blockIdx.x + gridDim.x*(blockIdx.y + blockIdx.z*gridDim.y);
-        uint32 blocks =  gridDim.x*gridDim.y*gridDim.z;
-        linid += linblockid*threads;
-
-        uint32 numregions = ((unsigned long long)memsize)/( ((unsigned long long)regionsize)*(sizeof(PTE)+pagesize)+sizeof(uint32));
-
-        uint32 numpages = numregions*regionsize;
-        //pointer is copied (copy is called page)
-        Page* page = (Page*)memory;
-        //sec check for alignment
-        //copy is checked
-        //PointerEquivalent alignmentstatus = ((PointerEquivalent)page) & (16 -1);
-        //if(alignmentstatus != 0)
-        //{
-        //  if(linid == 0){
-        //    printf("c Before:\n");
-        //    printf("c dataAlignment:   %d\n",16);
-        //    printf("c Alignmentstatus: %d\n",alignmentstatus);
-        //    printf("c size_t memsize   %llu byte\n", memsize);
-        //    printf("c void *memory     %p\n", page);
-        //  }
-        //  //copy is adjusted, potentially pointer to higher address now.
-        //  page =(Page*)(((PointerEquivalent)page) + 16 - alignmentstatus);
-        //  if(linid == 0) printf("c Heap Warning: memory to use not 16 byte aligned...\n");
-        //}
-        PTE* ptes = (PTE*)(page + numpages);
-        uint32* regions = (uint32*)(ptes + numpages);
-        //sec check for mem size
-        //this check refers to the original memory-pointer, which was not adjusted!
-        if( (char*)(regions + numregions) > (((char*)memory) + memsize) )
-        {
-          --numregions;
-          numpages = min(numregions*regionsize,numpages);
-          if(linid == 0) printf("c Heap Warning: needed to reduce number of regions to stay within memory limit\n");
-        }
-        //if(linid == 0) printf("Heap info: wasting %d bytes\n",(((POINTEREQUIVALENT)memory) + memsize) - (POINTEREQUIVALENT)(regions + numregions));
-
-        //if(linid == 0 && alignmentstatus != 0){
-        //  printf("c Was shrinked automatically to:\n");
-        //  printf("c size_t memsize   %llu byte\n", memsize);
-        //  printf("c void *memory     %p\n", page);
-        //}
-        threads *= blocks;
-
-        for(uint32 i = linid; i < numpages; i+= threads)
-        {
-          ptes[i].init();
-          page[i].init();
-        }
-        for(uint32 i = linid; i < numregions; i+= threads)
-          regions[i] = 0;
-
-        if(linid == 0)
-        {
-          _memsize = memsize;
-          _numpages = numpages;
-          _ptes = (volatile PTE*)ptes;
-          _page = page;
-          _regions =  regions;
-          _firstfreeblock = 0;
-          _pagebasedMutex = 0;
-          _firstFreePageBased = numpages-1;
-
-          if( (char*)&_page[numpages] > (char*)memory + memsize)
-            printf("error in heap alloc: numpages too high\n");
-        }
-
-      }
-
-      static __device__ bool isOOM(void* p, size_t s){
-        // one thread that requested memory returned null
-        return s && (p == nullptr);
-      }
-
-
-      template < typename T_DeviceAllocator >
-      static void* initHeap( T_DeviceAllocator* heap, void* pool, size_t memsize){
-        if( pool == nullptr && memsize != 0 )
-        {
-          throw std::invalid_argument(
-            "Scatter policy cannot use nullptr for non-empty memory pools. "
-            "Maybe you are using an incompatible ReservePoolPolicy or AlignmentPolicy."
-          );
-        }
-        ScatterKernelDetail::initKernel<<<1,256>>>(heap, pool, memsize);
-        return heap;
-      }
-
-      /** counts how many elements of a size fit inside a given page
-       *
-       * Examines a (potentially already used) page to find how many elements
-       * of size chunksize still fit on the page. This includes hierarchically
-       * organized pages and empty pages. The algorithm determines the number
-       * of chunks in the page in a manner similar to the allocation algorithm
-       * of CreationPolicies::Scatter.
-       *
-       * @param page the number of the page to examine. The page needs to be
-       *        formatted with a chunksize and potentially a hierarchy.
-       * @param chunksize the size of element that should be placed inside the
-       *        page. This size must be appropriate to the formatting of the
-       *        page.
-       */
-      __device__ unsigned countFreeChunksInPage(uint32 page, uint32 chunksize){
-        const uint32 filledChunks = _ptes[page].count;
-        if(chunksize <= HierarchyThreshold)
-        {
-          const uint32 segmentsize = chunksize*32 + sizeof(uint32); //each segment can hold 32 2nd-level chunks
-          const uint32 fullsegments = min(32,pagesize / segmentsize); //there might be space for more than 32 segments with 32 2nd-level chunks
-          const uint32 additional_chunks = calcAdditionalChunks(fullsegments, segmentsize, chunksize);
-          const uint32 level2Chunks = fullsegments * 32 + additional_chunks;
-          return level2Chunks - filledChunks;
-        }else{
-          const uint32 chunksinpage = min(pagesize / chunksize, 32); //without hierarchy, there can not be more than 32 chunks
-          return chunksinpage - filledChunks;
-        }
-      }
-
-
-      /** counts the number of available slots inside the heap
-       *
-       * Searches the heap for all possible locations of an element with size
-       * slotSize. The used traversal algorithms are similar to the allocation
-       * strategy of CreationPolicies::Scatter, to ensure comparable results.
-       * There are 3 different algorithms, based on the size of the requested
-       * slot: 1 slot spans over multiple pages, 1 slot fits in one chunk
-       * within a page, 1 slot fits in a fraction of a chunk.
-       *
-       * @param slotSize the amount of bytes that a single slot accounts for
-       * @param gid the id of the thread. this id does not have to correspond
-       *        with threadId.x, but there must be a continous range of ids
-       *        beginning from 0.
-       * @param stride the stride should be equal to the number of different
-       *        gids (and therefore of value max(gid)-1)
-       */
-      __device__ unsigned getAvailaibleSlotsDeviceFunction(size_t slotSize, int gid, int stride)
-      {
-        unsigned slotcount = 0;
-        if(slotSize < pagesize){ // multiple slots per page
-          for(uint32 currentpage = gid; currentpage < _numpages; currentpage += stride){
-            const uint32 maxchunksize = min(pagesize, wastefactor*(uint32)slotSize);
-            const uint32 region = currentpage/regionsize;
-            const uint32 regionfilllevel = _regions[region];
-
-            uint32 chunksize = _ptes[currentpage].chunksize;
-            if(chunksize >= slotSize && chunksize <= maxchunksize){ //how many chunks left? (each chunk is big enough)
-              slotcount += countFreeChunksInPage(currentpage, chunksize);
-            }else if(chunksize == 0){
-              chunksize = max((uint32)slotSize, minChunkSize1); //ensure minimum chunk size
-              slotcount += countFreeChunksInPage(currentpage, chunksize); //how many chunks fit in one page?
-            }else{
-              continue; //the chunks on this page are too small for the request :(
+                const unsigned int num = __popc(mask);
+                const unsigned int lanemask = mallocMC::lanemask_lt();
+                const unsigned int local_id = __popc(lanemask & mask);
+                for(unsigned int active = 0; active < num; ++active)
+                    if(active == local_id)
+                        res = allocPageBasedSingle(bytes);
+                return res;
             }
-          }
-        }else{ // 1 slot needs multiple pages
-          if(gid > 0) return 0; //do this serially
-          const uint32 pagestoalloc = divup((uint32)slotSize, pagesize);
-          uint32 freecount = 0;
-          for(uint32 currentpage = _numpages; currentpage > 0;){ //this already includes all superblocks
-            --currentpage;
-            if(_ptes[currentpage].chunksize == 0){
-              if(++freecount == pagestoalloc){
-                freecount = 0;
-                ++slotcount;
-              }
-            }else{ // the sequence of free pages was interrupted
-              freecount = 0;
+
+            /**
+             * deallocPageBased frees the memory placed on a sequence of pages
+             * @param mem pointer to the first page
+             * @param page the first page
+             * @param bytes the number of bytes to be freed
+             */
+            __device__ void
+            deallocPageBased(void * mem, uint32 page, uint32 bytes)
+            {
+                const uint32 pages = divup(bytes, pagesize);
+                for(uint32 p = page; p < page + pages; ++p) _page[p].init();
+                __threadfence();
+                for(uint32 p = page; p < page + pages; ++p)
+                    atomicCAS((uint32 *)&_ptes[p].chunksize, bytes, 0);
+                atomicMax((uint32 *)&_firstFreePageBased, page + pages - 1);
             }
-          }
-        }
-        return slotcount;
-      }
 
+        public:
+            /**
+             * create allocates the requested number of bytes via the heap.
+             * Coalescing has to be done before by another policy.
+             * @param bytes number of bytes to allocate
+             * @return pointer to the allocated memory
+             */
+            __device__ void * create(uint32 bytes)
+            {
+                if(bytes == 0)
+                    return 0;
+                // take care of padding
+                // bytes = (bytes + dataAlignment - 1) & ~(dataAlignment-1); //
+                // in alignment-policy
+                if(bytes < pagesize)
+                    // chunck based
+                    return allocChunked(bytes);
+                else
+                    // allocate a range of pages
+                    return allocPageBased(bytes);
+            }
 
-      /** Count, how many elements can be allocated at maximum
-       *
-       * Takes an input size and determines, how many elements of this size can
-       * be allocated with the CreationPolicy Scatter. This will return the
-       * maximum number of free slots of the indicated size. It is not
-       * guaranteed where these slots are (regarding fragmentation). Therefore,
-       * the practically usable number of slots might be smaller. This function
-       * is executed in parallel. Speedup can possibly increased by a higher
-       * amount ofparallel workers.
-       *
-       * @param slotSize the size of allocatable elements to count
-       * @param obj a reference to the allocator instance (host-side)
-       */
-    public:
-      template<typename T_DeviceAllocator>
-      static unsigned getAvailableSlotsHost(size_t const slotSize, T_DeviceAllocator* heap){
-        unsigned h_slots = 0;
-        unsigned* d_slots;
-        cudaMalloc((void**) &d_slots, sizeof(unsigned));
-        cudaMemcpy(d_slots, &h_slots, sizeof(unsigned), cudaMemcpyHostToDevice);
+            /**
+             * destroy frees the memory regions previously acllocted via create
+             * @param mempointer to the memory region to free
+             */
+            __device__ void destroy(void * mem)
+            {
+                if(mem == 0)
+                    return;
+                // lets see on which page we are on
+                const uint32 page = ((char *)mem - (char *)_page) / pagesize;
+                const uint32 chunksize = _ptes[page].chunksize;
 
-        ScatterKernelDetail::getAvailableSlotsKernel<<<64,256>>>(heap, slotSize, d_slots);
+                // is the pointer the beginning of a chunk?
+                const uint32 inpage_offset = ((char *)mem - _page[page].data);
+                const uint32 block = inpage_offset / chunksize;
+                const uint32 inblockoffset = inpage_offset - block * chunksize;
+                if(inblockoffset != 0)
+                {
+                    uint32 * counter
+                        = (uint32 *)(_page[page].data + block * chunksize);
+                    // coalesced mem free
+                    uint32 old = atomicSub(counter, 1);
+                    if(old != 1)
+                        return;
+                    mem = (void *)counter;
+                }
 
-        cudaMemcpy(&h_slots, d_slots, sizeof(unsigned), cudaMemcpyDeviceToHost);
-        cudaFree(d_slots);
-        return h_slots;
-      }
+                if(chunksize < pagesize)
+                    deallocChunked(mem, page, chunksize);
+                else
+                    deallocPageBased(mem, page, chunksize);
+            }
 
+            /**
+             * init inits the heap data structures
+             * the init method must be called before the heap can be used. the
+             * method can be called with an arbitrary number of threads, which
+             * will increase the inits efficiency
+             * @param memory pointer to the memory used for the heap
+             * @param memsize size of the memory in bytes
+             */
+            __device__ void initDeviceFunction(void * memory, size_t memsize)
+            {
+                uint32 linid = threadIdx.x
+                    + blockDim.x * (threadIdx.y + threadIdx.z * blockDim.y);
+                uint32 threads = blockDim.x * blockDim.y * blockDim.z;
+                const uint32 linblockid = blockIdx.x
+                    + gridDim.x * (blockIdx.y + blockIdx.z * gridDim.y);
+                uint32 blocks = gridDim.x * gridDim.y * gridDim.z;
+                linid += linblockid * threads;
 
-      /** Count, how many elements can be allocated at maximum
-       *
-       * Takes an input size and determines, how many elements of this size can
-       * be allocated with the CreationPolicy Scatter. This will return the
-       * maximum number of free slots of the indicated size. It is not
-       * guaranteed where these slots are (regarding fragmentation). Therefore,
-       * the practically usable number of slots might be smaller. This function
-       * is executed separately for each warp and does not cooperate with other
-       * warps. Maximum speed is expected if every thread in the warp executes
-       * the function.
-       * Uses 256 byte of shared memory.
-       *
-       * @param slotSize the size of allocatable elements to count
-       */
-      __device__ unsigned getAvailableSlotsAccelerator(size_t slotSize){
-        const int wId = warpid_withinblock(); //do not use warpid-function, since this value is not guaranteed to be stable across warp lifetime
+                uint32 numregions = ((unsigned long long)memsize)
+                    / (((unsigned long long)regionsize)
+                           * (sizeof(PTE) + pagesize)
+                       + sizeof(uint32));
+
+                uint32 numpages = numregions * regionsize;
+                // pointer is copied (copy is called page)
+                Page * page = (Page *)memory;
+                // sec check for alignment
+                // copy is checked
+                // PointerEquivalent alignmentstatus = ((PointerEquivalent)page)
+                // & (16 -1); if(alignmentstatus != 0)
+                //{
+                //  if(linid == 0){
+                //    printf("c Before:\n");
+                //    printf("c dataAlignment:   %d\n",16);
+                //    printf("c Alignmentstatus: %d\n",alignmentstatus);
+                //    printf("c size_t memsize   %llu byte\n", memsize);
+                //    printf("c void *memory     %p\n", page);
+                //  }
+                //  //copy is adjusted, potentially pointer to higher address
+                //  now. page =(Page*)(((PointerEquivalent)page) + 16 -
+                //  alignmentstatus); if(linid == 0) printf("c Heap Warning:
+                //  memory to use not 16 byte aligned...\n");
+                //}
+                PTE * ptes = (PTE *)(page + numpages);
+                uint32 * regions = (uint32 *)(ptes + numpages);
+                // sec check for mem size
+                // this check refers to the original memory-pointer, which was
+                // not adjusted!
+                if((char *)(regions + numregions)
+                   > (((char *)memory) + memsize))
+                {
+                    --numregions;
+                    numpages = min(numregions * regionsize, numpages);
+                    if(linid == 0)
+                        printf(
+                            "c Heap Warning: needed to reduce number of "
+                            "regions to stay within memory limit\n");
+                }
+                // if(linid == 0) printf("Heap info: wasting %d
+                // bytes\n",(((POINTEREQUIVALENT)memory) + memsize) -
+                // (POINTEREQUIVALENT)(regions + numregions));
+
+                // if(linid == 0 && alignmentstatus != 0){
+                //  printf("c Was shrinked automatically to:\n");
+                //  printf("c size_t memsize   %llu byte\n", memsize);
+                //  printf("c void *memory     %p\n", page);
+                //}
+                threads *= blocks;
+
+                for(uint32 i = linid; i < numpages; i += threads)
+                {
+                    ptes[i].init();
+                    page[i].init();
+                }
+                for(uint32 i = linid; i < numregions; i += threads)
+                    regions[i] = 0;
+
+                if(linid == 0)
+                {
+                    _memsize = memsize;
+                    _numpages = numpages;
+                    _ptes = (volatile PTE *)ptes;
+                    _page = page;
+                    _regions = regions;
+                    _firstfreeblock = 0;
+                    _pagebasedMutex = 0;
+                    _firstFreePageBased = numpages - 1;
+
+                    if((char *)&_page[numpages] > (char *)memory + memsize)
+                        printf("error in heap alloc: numpages too high\n");
+                }
+            }
+
+            static __device__ bool isOOM(void * p, size_t s)
+            {
+                // one thread that requested memory returned null
+                return s && (p == nullptr);
+            }
+
+            template<typename T_DeviceAllocator>
+            static void *
+            initHeap(T_DeviceAllocator * heap, void * pool, size_t memsize)
+            {
+                if(pool == nullptr && memsize != 0)
+                {
+                    throw std::invalid_argument(
+                        "Scatter policy cannot use nullptr for non-empty "
+                        "memory pools. "
+                        "Maybe you are using an incompatible ReservePoolPolicy "
+                        "or AlignmentPolicy.");
+                }
+                ScatterKernelDetail::initKernel<<<1, 256>>>(
+                    heap, pool, memsize);
+                return heap;
+            }
+
+            /** counts how many elements of a size fit inside a given page
+             *
+             * Examines a (potentially already used) page to find how many
+             * elements of size chunksize still fit on the page. This includes
+             * hierarchically organized pages and empty pages. The algorithm
+             * determines the number of chunks in the page in a manner similar
+             * to the allocation algorithm of CreationPolicies::Scatter.
+             *
+             * @param page the number of the page to examine. The page needs to
+             * be formatted with a chunksize and potentially a hierarchy.
+             * @param chunksize the size of element that should be placed inside
+             * the page. This size must be appropriate to the formatting of the
+             *        page.
+             */
+            __device__ unsigned
+            countFreeChunksInPage(uint32 page, uint32 chunksize)
+            {
+                const uint32 filledChunks = _ptes[page].count;
+                if(chunksize <= HierarchyThreshold)
+                {
+                    const uint32 segmentsize = chunksize * 32
+                        + sizeof(uint32); // each segment can hold 32 2nd-level
+                                          // chunks
+                    const uint32 fullsegments = min(
+                        32, pagesize / segmentsize); // there might be space for
+                                                     // more than 32 segments
+                                                     // with 32 2nd-level chunks
+                    const uint32 additional_chunks = calcAdditionalChunks(
+                        fullsegments, segmentsize, chunksize);
+                    const uint32 level2Chunks
+                        = fullsegments * 32 + additional_chunks;
+                    return level2Chunks - filledChunks;
+                }
+                else
+                {
+                    const uint32 chunksinpage = min(
+                        pagesize / chunksize,
+                        32); // without hierarchy, there can not be more than 32
+                             // chunks
+                    return chunksinpage - filledChunks;
+                }
+            }
+
+            /** counts the number of available slots inside the heap
+             *
+             * Searches the heap for all possible locations of an element with
+             * size slotSize. The used traversal algorithms are similar to the
+             * allocation strategy of CreationPolicies::Scatter, to ensure
+             * comparable results. There are 3 different algorithms, based on
+             * the size of the requested slot: 1 slot spans over multiple pages,
+             * 1 slot fits in one chunk within a page, 1 slot fits in a fraction
+             * of a chunk.
+             *
+             * @param slotSize the amount of bytes that a single slot accounts
+             * for
+             * @param gid the id of the thread. this id does not have to
+             * correspond with threadId.x, but there must be a continous range
+             * of ids beginning from 0.
+             * @param stride the stride should be equal to the number of
+             * different gids (and therefore of value max(gid)-1)
+             */
+            __device__ unsigned getAvailaibleSlotsDeviceFunction(
+                size_t slotSize,
+                int gid,
+                int stride)
+            {
+                unsigned slotcount = 0;
+                if(slotSize < pagesize)
+                { // multiple slots per page
+                    for(uint32 currentpage = gid; currentpage < _numpages;
+                        currentpage += stride)
+                    {
+                        const uint32 maxchunksize
+                            = min(pagesize, wastefactor * (uint32)slotSize);
+                        const uint32 region = currentpage / regionsize;
+                        const uint32 regionfilllevel = _regions[region];
+
+                        uint32 chunksize = _ptes[currentpage].chunksize;
+                        if(chunksize >= slotSize && chunksize <= maxchunksize)
+                        { // how many chunks left? (each chunk is big enough)
+                            slotcount += countFreeChunksInPage(
+                                currentpage, chunksize);
+                        }
+                        else if(chunksize == 0)
+                        {
+                            chunksize = max(
+                                (uint32)slotSize,
+                                minChunkSize1); // ensure minimum chunk size
+                            slotcount += countFreeChunksInPage(
+                                currentpage,
+                                chunksize); // how many chunks fit in one page?
+                        }
+                        else
+                        {
+                            continue; // the chunks on this page are too small
+                                      // for the request :(
+                        }
+                    }
+                }
+                else
+                { // 1 slot needs multiple pages
+                    if(gid > 0)
+                        return 0; // do this serially
+                    const uint32 pagestoalloc
+                        = divup((uint32)slotSize, pagesize);
+                    uint32 freecount = 0;
+                    for(uint32 currentpage = _numpages; currentpage > 0;)
+                    { // this already includes all superblocks
+                        --currentpage;
+                        if(_ptes[currentpage].chunksize == 0)
+                        {
+                            if(++freecount == pagestoalloc)
+                            {
+                                freecount = 0;
+                                ++slotcount;
+                            }
+                        }
+                        else
+                        { // the sequence of free pages was interrupted
+                            freecount = 0;
+                        }
+                    }
+                }
+                return slotcount;
+            }
+
+            /** Count, how many elements can be allocated at maximum
+             *
+             * Takes an input size and determines, how many elements of this
+             * size can be allocated with the CreationPolicy Scatter. This will
+             * return the maximum number of free slots of the indicated size. It
+             * is not guaranteed where these slots are (regarding
+             * fragmentation). Therefore, the practically usable number of slots
+             * might be smaller. This function is executed in parallel. Speedup
+             * can possibly increased by a higher amount ofparallel workers.
+             *
+             * @param slotSize the size of allocatable elements to count
+             * @param obj a reference to the allocator instance (host-side)
+             */
+        public:
+            template<typename T_DeviceAllocator>
+            static unsigned getAvailableSlotsHost(
+                size_t const slotSize,
+                T_DeviceAllocator * heap)
+            {
+                unsigned h_slots = 0;
+                unsigned * d_slots;
+                cudaMalloc((void **)&d_slots, sizeof(unsigned));
+                cudaMemcpy(
+                    d_slots,
+                    &h_slots,
+                    sizeof(unsigned),
+                    cudaMemcpyHostToDevice);
+
+                ScatterKernelDetail::getAvailableSlotsKernel<<<64, 256>>>(
+                    heap, slotSize, d_slots);
+
+                cudaMemcpy(
+                    &h_slots,
+                    d_slots,
+                    sizeof(unsigned),
+                    cudaMemcpyDeviceToHost);
+                cudaFree(d_slots);
+                return h_slots;
+            }
+
+            /** Count, how many elements can be allocated at maximum
+             *
+             * Takes an input size and determines, how many elements of this
+             * size can be allocated with the CreationPolicy Scatter. This will
+             * return the maximum number of free slots of the indicated size. It
+             * is not guaranteed where these slots are (regarding
+             * fragmentation). Therefore, the practically usable number of slots
+             * might be smaller. This function is executed separately for each
+             * warp and does not cooperate with other warps. Maximum speed is
+             * expected if every thread in the warp executes the function. Uses
+             * 256 byte of shared memory.
+             *
+             * @param slotSize the size of allocatable elements to count
+             */
+            __device__ unsigned getAvailableSlotsAccelerator(size_t slotSize)
+            {
+                const int wId
+                    = warpid_withinblock(); // do not use warpid-function, since
+                                            // this value is not guaranteed to be
+                                            // stable across warp lifetime
 
 #if(__CUDACC_VER_MAJOR__ >= 9)
-        const uint32 activeThreads  = __popc(__activemask());
+                const uint32 activeThreads = __popc(__activemask());
 #else
-        const uint32 activeThreads  = __popc(__ballot(true));
+                const uint32 activeThreads = __popc(__ballot(true));
 #endif
-        __shared__ uint32 activePerWarp[MaxThreadsPerBlock::value / WarpSize::value]; //maximum number of warps in a block
-        __shared__ unsigned warpResults[MaxThreadsPerBlock::value / WarpSize::value];
-        warpResults[wId]   = 0;
-        activePerWarp[wId] = 0;
+                __shared__ uint32 activePerWarp
+                    [MaxThreadsPerBlock::value
+                     / WarpSize::value]; // maximum number of warps in a block
+                __shared__ unsigned
+                    warpResults[MaxThreadsPerBlock::value / WarpSize::value];
+                warpResults[wId] = 0;
+                activePerWarp[wId] = 0;
 
-        // the active threads obtain an id from 0 to activeThreads-1
-        if (slotSize == 0) return 0;
-        const int linearId = atomicAdd(&activePerWarp[wId], 1);
+                // the active threads obtain an id from 0 to activeThreads-1
+                if(slotSize == 0)
+                    return 0;
+                const int linearId = atomicAdd(&activePerWarp[wId], 1);
 
-        //printf("Block %d, id %d: activeThreads=%d linearId=%d\n",blockIdx.x,threadIdx.x,activeThreads,linearId);
-        const unsigned temp = getAvailaibleSlotsDeviceFunction(slotSize, linearId, activeThreads);
-        if(temp) atomicAdd(&warpResults[wId], temp);
-        __threadfence_block();
-        return warpResults[wId];
-      }
+                // printf("Block %d, id %d: activeThreads=%d
+                // linearId=%d\n",blockIdx.x,threadIdx.x,activeThreads,linearId);
+                const unsigned temp = getAvailaibleSlotsDeviceFunction(
+                    slotSize, linearId, activeThreads);
+                if(temp)
+                    atomicAdd(&warpResults[wId], temp);
+                __threadfence_block();
+                return warpResults[wId];
+            }
 
-      static std::string classname(){
-        std::stringstream ss;
-        ss << "Scatter[";
-        ss << pagesize        << ",";
-        ss << accessblocks    << ",";
-        ss << regionsize      << ",";
-        ss << wastefactor     << ",";
-        ss << resetfreedpages << ",";
-        ss << hashingK        << ",";
-        ss << hashingDistMP   << ",";
-        ss << hashingDistWP   << ",";
-        ss << hashingDistWPRel<< "]";
-        return ss.str();
-      }
-  };
+            static std::string classname()
+            {
+                std::stringstream ss;
+                ss << "Scatter[";
+                ss << pagesize << ",";
+                ss << accessblocks << ",";
+                ss << regionsize << ",";
+                ss << wastefactor << ",";
+                ss << resetfreedpages << ",";
+                ss << hashingK << ",";
+                ss << hashingDistMP << ",";
+                ss << hashingDistWP << ",";
+                ss << hashingDistWPRel << "]";
+                return ss.str();
+            }
+        };
 
-} //namespace CreationPolicies
-} //namespace mallocMC
+    } // namespace CreationPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -390,7 +390,8 @@ namespace mallocMC
              * to obtain a free chunk
              */
             __device__ inline auto
-            addChunkNoHierarchy(uint32 chunksize, uint32 page, uint32 spots) -> void *
+            addChunkNoHierarchy(uint32 chunksize, uint32 page, uint32 spots)
+                -> void *
             {
                 const int spot = usespot((uint32 *)&_ptes[page].bitmask, spots);
                 if(spot == -1)
@@ -405,7 +406,8 @@ namespace mallocMC
              * @return pointer to a free chunk on the page, 0 if we were unable
              * to obtain a free chunk
              */
-            __device__ inline auto tryUsePage(uint32 page, uint32 chunksize) -> void *
+            __device__ inline auto tryUsePage(uint32 page, uint32 chunksize)
+                -> void *
             {
                 void * chunk_ptr = nullptr;
 
@@ -926,7 +928,8 @@ namespace mallocMC
 
             template<typename T_DeviceAllocator>
             static auto
-            initHeap(T_DeviceAllocator * heap, void * pool, size_t memsize) -> void *
+            initHeap(T_DeviceAllocator * heap, void * pool, size_t memsize)
+                -> void *
             {
                 if(pool == nullptr && memsize != 0)
                 {
@@ -955,8 +958,8 @@ namespace mallocMC
              * the page. This size must be appropriate to the formatting of the
              *        page.
              */
-            __device__ auto
-            countFreeChunksInPage(uint32 page, uint32 chunksize) -> unsigned
+            __device__ auto countFreeChunksInPage(uint32 page, uint32 chunksize)
+                -> unsigned
             {
                 const uint32 filledChunks = _ptes[page].count;
                 if(chunksize <= HierarchyThreshold)
@@ -1121,12 +1124,13 @@ namespace mallocMC
              *
              * @param slotSize the size of allocatable elements to count
              */
-            __device__ auto getAvailableSlotsAccelerator(size_t slotSize) -> unsigned
+            __device__ auto getAvailableSlotsAccelerator(size_t slotSize)
+                -> unsigned
             {
                 const int wId
                     = warpid_withinblock(); // do not use warpid-function, since
-                                            // this value is not guaranteed to be
-                                            // stable across warp lifetime
+                                            // this value is not guaranteed to
+                                            // be stable across warp lifetime
 
 #if(__CUDACC_VER_MAJOR__ >= 9)
                 const uint32 activeThreads = __popc(__activemask());

--- a/src/include/mallocMC/device_allocator.hpp
+++ b/src/include/mallocMC/device_allocator.hpp
@@ -36,65 +36,52 @@
 #include <cstdint>
 #include <cstdio>
 
-namespace mallocMC{
-namespace detail{
-
-    /**
-     * @brief Template class to call getAvailableSlots[Host|Accelerator] if the CreationPolicy provides it.
-     *
-     * Returns 0 else.
-     *
-     * @tparam T_Allocator The type of the Allocator to be used
-     * @tparam T_isHost True for the host call, false for the accelerator call
-     * @tparam T_providesAvailableSlots If the CreationPolicy provides getAvailableSlots[Host|Accelerator] (auto filled, do not set)
-     */
-    template<
-        typename T_Allocator,
-        bool T_providesAvailableSlots
-    >
-    struct GetAvailableSlotsIfAvailAcc
+namespace mallocMC
+{
+    namespace detail
     {
-        MAMC_ACCELERATOR static
-        unsigned
-        getAvailableSlots(
-            size_t,
-            T_Allocator &
-        )
+        /**
+         * @brief Template class to call getAvailableSlots[Host|Accelerator] if
+         * the CreationPolicy provides it.
+         *
+         * Returns 0 else.
+         *
+         * @tparam T_Allocator The type of the Allocator to be used
+         * @tparam T_isHost True for the host call, false for the accelerator
+         * call
+         * @tparam T_providesAvailableSlots If the CreationPolicy provides
+         * getAvailableSlots[Host|Accelerator] (auto filled, do not set)
+         */
+        template<typename T_Allocator, bool T_providesAvailableSlots>
+        struct GetAvailableSlotsIfAvailAcc
         {
-            return 0;
-        }
+            MAMC_ACCELERATOR static unsigned
+            getAvailableSlots(size_t, T_Allocator &)
+            {
+                return 0;
+            }
+        };
 
-    };
-
-    template<
-        typename T_Allocator
-    >
-    struct GetAvailableSlotsIfAvailAcc<
-        T_Allocator,
-        true
-    >{
-        MAMC_ACCELERATOR static
-        unsigned
-        getAvailableSlots(
-            size_t slotSize,
-            T_Allocator& alloc
-        )
+        template<typename T_Allocator>
+        struct GetAvailableSlotsIfAvailAcc<T_Allocator, true>
         {
-            return alloc.T_Allocator::CreationPolicy
-                ::getAvailableSlotsAccelerator( slotSize );
-        }
+            MAMC_ACCELERATOR static unsigned
+            getAvailableSlots(size_t slotSize, T_Allocator & alloc)
+            {
+                return alloc
+                    .T_Allocator::CreationPolicy ::getAvailableSlotsAccelerator(
+                        slotSize);
+            }
+        };
 
-    };
-
-} // namespace detail
-
+    } // namespace detail
 
     /**
      * @brief "HostClass" that combines all policies to a useful allocator
      *
-     * This class implements the necessary glue-logic to form an actual allocator
-     * from the provided policies. It implements the public interface and
-     * executes some constraint checking based on an instance of the class
+     * This class implements the necessary glue-logic to form an actual
+     * allocator from the provided policies. It implements the public interface
+     * and executes some constraint checking based on an instance of the class
      * PolicyConstraints.
      *
      * @tparam T_CreationPolicy The desired type of a CreationPolicy
@@ -107,63 +94,51 @@ namespace detail{
         typename T_CreationPolicy,
         typename T_DistributionPolicy,
         typename T_OOMPolicy,
-        typename T_AlignmentPolicy
-    >
-    class DeviceAllocator :
-        public T_CreationPolicy
+        typename T_AlignmentPolicy>
+    class DeviceAllocator : public T_CreationPolicy
     {
         using uint32 = std::uint32_t;
+
     public:
         using CreationPolicy = T_CreationPolicy;
         using DistributionPolicy = T_DistributionPolicy;
         using OOMPolicy = T_OOMPolicy;
         using AlignmentPolicy = T_AlignmentPolicy;
 
-        void* pool;
+        void * pool;
 
         MAMC_ACCELERATOR
-        void*
-        malloc(
-            size_t bytes
-        )
+        void * malloc(size_t bytes)
         {
             DistributionPolicy distributionPolicy;
-            bytes = AlignmentPolicy::applyPadding( bytes );
-            uint32 req_size = distributionPolicy.collect( bytes );
-            void* memBlock = CreationPolicy::create( req_size );
-            const bool oom = CreationPolicy::isOOM( memBlock, req_size );
-            if( oom )
-                memBlock = OOMPolicy::handleOOM( memBlock );
-            void* myPart = distributionPolicy.distribute( memBlock );
+            bytes = AlignmentPolicy::applyPadding(bytes);
+            uint32 req_size = distributionPolicy.collect(bytes);
+            void * memBlock = CreationPolicy::create(req_size);
+            const bool oom = CreationPolicy::isOOM(memBlock, req_size);
+            if(oom)
+                memBlock = OOMPolicy::handleOOM(memBlock);
+            void * myPart = distributionPolicy.distribute(memBlock);
             return myPart;
         }
 
         MAMC_ACCELERATOR
-        void
-        free(
-            void* p
-        )
+        void free(void * p)
         {
-            CreationPolicy::destroy( p );
+            CreationPolicy::destroy(p);
         }
-
 
         /* polymorphism over the availability of getAvailableSlots for calling
          * from the accelerator
          */
         MAMC_ACCELERATOR
-        unsigned
-        getAvailableSlots(
-            size_t slotSize
-        )
+        unsigned getAvailableSlots(size_t slotSize)
         {
-            slotSize = AlignmentPolicy::applyPadding( slotSize );
+            slotSize = AlignmentPolicy::applyPadding(slotSize);
             return detail::GetAvailableSlotsIfAvailAcc<
                 DeviceAllocator,
-                Traits< DeviceAllocator >::providesAvailableSlots
-            >::getAvailableSlots( slotSize, *this );
+                Traits<DeviceAllocator>::providesAvailableSlots>::
+                getAvailableSlots(slotSize, *this);
         }
-
     };
 
 } // namespace mallocMC

--- a/src/include/mallocMC/device_allocator.hpp
+++ b/src/include/mallocMC/device_allocator.hpp
@@ -55,8 +55,8 @@ namespace mallocMC
         template<typename T_Allocator, bool T_providesAvailableSlots>
         struct GetAvailableSlotsIfAvailAcc
         {
-            MAMC_ACCELERATOR static unsigned
-            getAvailableSlots(size_t, T_Allocator &)
+            MAMC_ACCELERATOR static auto
+            getAvailableSlots(size_t, T_Allocator &) -> unsigned
             {
                 return 0;
             }
@@ -65,8 +65,8 @@ namespace mallocMC
         template<typename T_Allocator>
         struct GetAvailableSlotsIfAvailAcc<T_Allocator, true>
         {
-            MAMC_ACCELERATOR static unsigned
-            getAvailableSlots(size_t slotSize, T_Allocator & alloc)
+            MAMC_ACCELERATOR static auto
+            getAvailableSlots(size_t slotSize, T_Allocator & alloc) -> unsigned
             {
                 return alloc
                     .T_Allocator::CreationPolicy ::getAvailableSlotsAccelerator(
@@ -108,7 +108,7 @@ namespace mallocMC
         void * pool;
 
         MAMC_ACCELERATOR
-        void * malloc(size_t bytes)
+        auto malloc(size_t bytes) -> void *
         {
             DistributionPolicy distributionPolicy;
             bytes = AlignmentPolicy::applyPadding(bytes);
@@ -131,7 +131,7 @@ namespace mallocMC
          * from the accelerator
          */
         MAMC_ACCELERATOR
-        unsigned getAvailableSlots(size_t slotSize)
+        auto getAvailableSlots(size_t slotSize) -> unsigned
         {
             slotSize = AlignmentPolicy::applyPadding(slotSize);
             return detail::GetAvailableSlotsIfAvailAcc<

--- a/src/include/mallocMC/distributionPolicies/Noop.hpp
+++ b/src/include/mallocMC/distributionPolicies/Noop.hpp
@@ -27,16 +27,17 @@
 
 #pragma once
 
-namespace mallocMC{
-namespace DistributionPolicies{
+namespace mallocMC
+{
+    namespace DistributionPolicies
+    {
+        /**
+         * @brief a policy that does nothing
+         *
+         * This DistributionPolicy will not perform any distribution, but only
+         * return its input (identity function)
+         */
+        class Noop;
 
-  /**
-   * @brief a policy that does nothing
-   *
-   * This DistributionPolicy will not perform any distribution, but only return
-   * its input (identity function)
-   */
-  class Noop;
-
-} //namespace DistributionPolicies
-} //namespace mallocMC
+    } // namespace DistributionPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
@@ -43,18 +43,18 @@ namespace mallocMC
 
         public:
             MAMC_ACCELERATOR
-            uint32 collect(uint32 bytes) const
+            auto collect(uint32 bytes) const -> uint32
             {
                 return bytes;
             }
 
             MAMC_ACCELERATOR
-            void * distribute(void * allocatedMem) const
+            auto distribute(void * allocatedMem) const -> void *
             {
                 return allocatedMem;
             }
 
-            static std::string classname()
+            static auto classname() -> std::string
             {
                 return "Noop";
             }

--- a/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
@@ -27,34 +27,38 @@
 
 #pragma once
 
-#include <cstdint>
-#include <string>
-
 #include "../mallocMC_prefixes.hpp"
 #include "Noop.hpp"
 
-namespace mallocMC{
-namespace DistributionPolicies{
+#include <cstdint>
+#include <string>
 
-  class Noop
-  {
-    using uint32 = std::uint32_t;
+namespace mallocMC
+{
+    namespace DistributionPolicies
+    {
+        class Noop
+        {
+            using uint32 = std::uint32_t;
 
-    public:
-    MAMC_ACCELERATOR
-    uint32 collect(uint32 bytes) const {
-      return bytes;
-    }
+        public:
+            MAMC_ACCELERATOR
+            uint32 collect(uint32 bytes) const
+            {
+                return bytes;
+            }
 
-    MAMC_ACCELERATOR
-    void* distribute(void* allocatedMem) const {
-      return allocatedMem;
-    }
+            MAMC_ACCELERATOR
+            void * distribute(void * allocatedMem) const
+            {
+                return allocatedMem;
+            }
 
-    static std::string classname(){
-      return "Noop";
-    }
-  };
+            static std::string classname()
+            {
+                return "Noop";
+            }
+        };
 
-} //namespace DistributionPolicies
-} //namespace mallocMC
+    } // namespace DistributionPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
@@ -33,36 +33,39 @@
 
 #pragma once
 
-namespace mallocMC{
-namespace DistributionPolicies{
+namespace mallocMC
+{
+    namespace DistributionPolicies
+    {
+        namespace XMallocSIMDConf
+        {
+            struct DefaultXMallocConfig
+            {
+                static constexpr auto pagesize = 4096;
+            };
+        } // namespace XMallocSIMDConf
 
-  namespace XMallocSIMDConf{
-    struct DefaultXMallocConfig{
-      static constexpr auto pagesize = 4096;
-    };
-  } // namespace XMallocSIMDConf
+        /**
+         * @brief SIMD optimized chunk resizing in the style of XMalloc
+         *
+         * This DistributionPolicy can take the memory requests from a group of
+         * worker threads and combine them, so that only one of the workers will
+         * allocate the whole request. Later, each worker gets an appropriate
+         * offset into the allocated chunk. This is beneficial for SIMD
+         * architectures since only one of the workers has to compete for the
+         * resource.  This algorithm is inspired by the XMalloc memory allocator
+         * (http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=5577907&tag=1)
+         * and its implementation in ScatterAlloc
+         * (http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=6339604)
+         * XMallocSIMD is inteded to be used with Nvidia CUDA capable
+         * accelerators that support at least compute capability 2.0
+         *
+         * @tparam T_Config (optional) The configuration struct to overwrite
+         *        default configuration. The default can be obtained through
+         *        XMallocSIMD<>::Properties
+         */
+        template<class T_Config = XMallocSIMDConf::DefaultXMallocConfig>
+        class XMallocSIMD;
 
-  /**
-   * @brief SIMD optimized chunk resizing in the style of XMalloc
-   *
-   * This DistributionPolicy can take the memory requests from a group of
-   * worker threads and combine them, so that only one of the workers will
-   * allocate the whole request. Later, each worker gets an appropriate offset
-   * into the allocated chunk. This is beneficial for SIMD architectures since
-   * only one of the workers has to compete for the resource.  This algorithm
-   * is inspired by the XMalloc memory allocator
-   * (http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=5577907&tag=1) and
-   * its implementation in ScatterAlloc
-   * (http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=6339604)
-   * XMallocSIMD is inteded to be used with Nvidia CUDA capable accelerators
-   * that support at least compute capability 2.0
-   *
-   * @tparam T_Config (optional) The configuration struct to overwrite
-   *        default configuration. The default can be obtained through
-   *        XMallocSIMD<>::Properties
-   */
-  template<class T_Config = XMallocSIMDConf::DefaultXMallocConfig>
-  class XMallocSIMD;
-
-} //namespace DistributionPolicies
-} //namespace mallocMC
+    } // namespace DistributionPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -33,38 +33,43 @@
 
 #pragma once
 
+#include "../mallocMC_prefixes.hpp"
+#include "../mallocMC_utils.hpp"
+#include "XMallocSIMD.hpp"
+
 #include <cstdint>
 #include <limits>
 #include <sstream>
 #include <string>
 
-#include "../mallocMC_prefixes.hpp"
-#include "../mallocMC_utils.hpp"
-#include "XMallocSIMD.hpp"
+namespace mallocMC
+{
+    namespace DistributionPolicies
+    {
+        template<class T_Config>
+        class XMallocSIMD
+        {
+        private:
+            using uint32 = std::uint32_t;
+            bool can_use_coalescing;
+            uint32 warpid;
+            uint32 myoffset;
+            uint32 threadcount;
+            uint32 req_size;
 
-namespace mallocMC{
-namespace DistributionPolicies{
+        public:
+            using Properties = T_Config;
 
-  template<class T_Config>
-  class XMallocSIMD
-  {
-    private:
+            MAMC_ACCELERATOR
+            XMallocSIMD() :
+                    can_use_coalescing(false),
+                    warpid(warpid_withinblock()),
+                    myoffset(0),
+                    threadcount(0),
+                    req_size(0)
+            {}
 
-      using uint32 = std::uint32_t;
-      bool can_use_coalescing;
-      uint32 warpid;
-      uint32 myoffset;
-      uint32 threadcount;
-      uint32 req_size;
-    public:
-      using Properties = T_Config;
-
-      MAMC_ACCELERATOR
-      XMallocSIMD() : can_use_coalescing(false), warpid(warpid_withinblock()),
-        myoffset(0), threadcount(0), req_size(0)
-      {}
-
-    private:
+        private:
 /** Allow for a hierarchical validation of parameters:
  *
  * shipped default-parameters (in the inherited struct) have lowest precedence.
@@ -77,77 +82,80 @@ namespace DistributionPolicies{
 #ifndef MALLOCMC_DP_XMALLOCSIMD_PAGESIZE
 #define MALLOCMC_DP_XMALLOCSIMD_PAGESIZE (Properties::pagesize)
 #endif
-      static constexpr uint32 pagesize      = MALLOCMC_DP_XMALLOCSIMD_PAGESIZE;
+            static constexpr uint32 pagesize = MALLOCMC_DP_XMALLOCSIMD_PAGESIZE;
 
-    public:
-      static constexpr uint32 _pagesize = pagesize;
+        public:
+            static constexpr uint32 _pagesize = pagesize;
 
-      MAMC_ACCELERATOR
-      uint32 collect(uint32 bytes){
+            MAMC_ACCELERATOR
+            uint32 collect(uint32 bytes)
+            {
+                can_use_coalescing = false;
+                myoffset = 0;
+                threadcount = 0;
 
-        can_use_coalescing = false;
-        myoffset = 0;
-        threadcount = 0;
+                // init with initial counter
+                __shared__ uint32 warp_sizecounter
+                    [MaxThreadsPerBlock::value / WarpSize::value];
+                warp_sizecounter[warpid] = 16;
 
-        //init with initial counter
-        __shared__ uint32 warp_sizecounter[MaxThreadsPerBlock::value / WarpSize::value];
-        warp_sizecounter[warpid] = 16;
-
-        //second half: make sure that all coalesced allocations can fit within one page
-        //necessary for offset calculation
-        bool coalescible = bytes > 0 && bytes < (pagesize / 32);
+                // second half: make sure that all coalesced allocations can fit
+                // within one page necessary for offset calculation
+                bool coalescible = bytes > 0 && bytes < (pagesize / 32);
 #if(__CUDACC_VER_MAJOR__ >= 9)
-        threadcount = __popc(__ballot_sync(__activemask(), coalescible));
+                threadcount
+                    = __popc(__ballot_sync(__activemask(), coalescible));
 #else
-        threadcount = __popc(__ballot(coalescible));
+                threadcount = __popc(__ballot(coalescible));
 #endif
-        if (coalescible && threadcount > 1)
-        {
-          myoffset = atomicAdd(&warp_sizecounter[warpid], bytes);
-          can_use_coalescing = true;
-        }
+                if(coalescible && threadcount > 1)
+                {
+                    myoffset = atomicAdd(&warp_sizecounter[warpid], bytes);
+                    can_use_coalescing = true;
+                }
 
-        req_size = bytes;
-        if (can_use_coalescing)
-          req_size = (myoffset == 16) ? warp_sizecounter[warpid] : 0;
+                req_size = bytes;
+                if(can_use_coalescing)
+                    req_size = (myoffset == 16) ? warp_sizecounter[warpid] : 0;
 
-        return req_size;
-      }
+                return req_size;
+            }
 
+            MAMC_ACCELERATOR
+            void * distribute(void * allocatedMem)
+            {
+                __shared__ char *
+                    warp_res[MaxThreadsPerBlock::value / WarpSize::value];
 
-      MAMC_ACCELERATOR
-      void* distribute(void* allocatedMem){
-        __shared__ char* warp_res[MaxThreadsPerBlock::value / WarpSize::value];
+                char * myalloc = (char *)allocatedMem;
+                if(req_size && can_use_coalescing)
+                {
+                    warp_res[warpid] = myalloc;
+                    if(myalloc != 0)
+                        *(uint32 *)myalloc = threadcount;
+                }
+                __threadfence_block();
 
-        char* myalloc = (char*) allocatedMem;
-        if (req_size && can_use_coalescing)
-        {
-          warp_res[warpid] = myalloc;
-          if (myalloc != 0)
-            *(uint32*)myalloc = threadcount;
-        }
-        __threadfence_block();
+                void * myres = myalloc;
+                if(can_use_coalescing)
+                {
+                    if(warp_res[warpid] != 0)
+                        myres = warp_res[warpid] + myoffset;
+                    else
+                        myres = 0;
+                }
+                return myres;
+            }
 
-        void *myres = myalloc;
-        if(can_use_coalescing)
-        {
-          if(warp_res[warpid] != 0)
-            myres = warp_res[warpid] + myoffset;
-          else
-            myres = 0;
-        }
-        return myres;
-      }
+            MAMC_HOST
+            static std::string classname()
+            {
+                std::stringstream ss;
+                ss << "XMallocSIMD[" << pagesize << "]";
+                return ss.str();
+            }
+        };
 
-      MAMC_HOST
-      static std::string classname(){
-        std::stringstream ss;
-        ss << "XMallocSIMD[" << pagesize << "]";
-        return ss.str();
-      }
+    } // namespace DistributionPolicies
 
-  };
-
-} //namespace DistributionPolicies
-
-} //namespace mallocMC
+} // namespace mallocMC

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -88,7 +88,7 @@ namespace mallocMC
             static constexpr uint32 _pagesize = pagesize;
 
             MAMC_ACCELERATOR
-            uint32 collect(uint32 bytes)
+            auto collect(uint32 bytes) -> uint32
             {
                 can_use_coalescing = false;
                 myoffset = 0;
@@ -122,7 +122,7 @@ namespace mallocMC
             }
 
             MAMC_ACCELERATOR
-            void * distribute(void * allocatedMem)
+            auto distribute(void * allocatedMem) -> void *
             {
                 __shared__ char *
                     warp_res[MaxThreadsPerBlock::value / WarpSize::value];
@@ -148,7 +148,7 @@ namespace mallocMC
             }
 
             MAMC_HOST
-            static std::string classname()
+            static auto classname() -> std::string
             {
                 std::stringstream ss;
                 ss << "XMallocSIMD[" << pagesize << "]";

--- a/src/include/mallocMC/mallocMC_allocator_handle.hpp
+++ b/src/include/mallocMC/mallocMC_allocator_handle.hpp
@@ -30,49 +30,34 @@
 
 #include "mallocMC_prefixes.hpp"
 
-namespace mallocMC{
-
-    template <typename T_HostAllocator>
+namespace mallocMC
+{
+    template<typename T_HostAllocator>
     struct AllocatorHandleImpl
     {
         using DevAllocator = typename T_HostAllocator::DevAllocator;
 
-        DevAllocator* devAllocator;
+        DevAllocator * devAllocator;
 
-        explicit AllocatorHandleImpl(
-            DevAllocator* p
-        ) :
-            devAllocator( p )
+        explicit AllocatorHandleImpl(DevAllocator * p) : devAllocator(p) {}
+
+        MAMC_ACCELERATOR
+        void * malloc(size_t size)
         {
+            return devAllocator->malloc(size);
         }
 
         MAMC_ACCELERATOR
-        void*
-        malloc(
-            size_t size
-        )
+        void free(void * p)
         {
-            return devAllocator->malloc( size );
+            devAllocator->free(p);
         }
 
         MAMC_ACCELERATOR
-        void
-        free(
-            void* p
-        )
+        unsigned getAvailableSlots(size_t slotSize)
         {
-            devAllocator->free( p );
+            return devAllocator->getAvailableSlots(slotSize);
         }
-
-        MAMC_ACCELERATOR
-        unsigned
-        getAvailableSlots(
-            size_t slotSize
-        )
-        {
-            return devAllocator->getAvailableSlots( slotSize );
-        }
-
     };
 
 } // namespace mallocMC

--- a/src/include/mallocMC/mallocMC_allocator_handle.hpp
+++ b/src/include/mallocMC/mallocMC_allocator_handle.hpp
@@ -42,7 +42,7 @@ namespace mallocMC
         explicit AllocatorHandleImpl(DevAllocator * p) : devAllocator(p) {}
 
         MAMC_ACCELERATOR
-        void * malloc(size_t size)
+        auto malloc(size_t size) -> void *
         {
             return devAllocator->malloc(size);
         }
@@ -54,7 +54,7 @@ namespace mallocMC
         }
 
         MAMC_ACCELERATOR
-        unsigned getAvailableSlots(size_t slotSize)
+        auto getAvailableSlots(size_t slotSize) -> unsigned
         {
             return devAllocator->getAvailableSlots(slotSize);
         }

--- a/src/include/mallocMC/mallocMC_constraints.hpp
+++ b/src/include/mallocMC/mallocMC_constraints.hpp
@@ -31,55 +31,68 @@
 #include "creationPolicies/Scatter.hpp"
 #include "distributionPolicies/XMallocSIMD.hpp"
 
-namespace mallocMC{
+namespace mallocMC
+{
+    /** The default PolicyCheckers (do always succeed)
+     */
+    template<typename Policy1>
+    class PolicyCheck1
+    {};
 
-  /** The default PolicyCheckers (do always succeed)
-   */
-  template<typename Policy1>
-  class PolicyCheck1{};
+    template<typename Policy1, typename Policy2>
+    class PolicyCheck2
+    {};
 
-  template<typename Policy1, typename Policy2>
-  class PolicyCheck2{};
+    template<typename Policy1, typename Policy2, typename Policy3>
+    class PolicyCheck3
+    {};
 
-  template<typename Policy1, typename Policy2, typename Policy3>
-  class PolicyCheck3{};
+    template<
+        typename Policy1,
+        typename Policy2,
+        typename Policy3,
+        typename Policy4>
+    class PolicyCheck4
+    {};
 
-  template<typename Policy1, typename Policy2, typename Policy3, typename Policy4>
-  class PolicyCheck4{};
+    template<
+        typename Policy1,
+        typename Policy2,
+        typename Policy3,
+        typename Policy4,
+        typename Policy5>
+    class PolicyCheck5
+    {};
 
-  template<typename Policy1, typename Policy2, typename Policy3, typename Policy4, typename Policy5>
-  class PolicyCheck5{};
+    /** Enforces constraints on policies or combinations of polices
+     *
+     * Uses template specialization of PolicyChecker
+     */
+    template<
+        typename T_CreationPolicy,
+        typename T_DistributionPolicy,
+        typename T_OOMPolicy,
+        typename T_GetHeapPolicy,
+        typename T_AlignmentPolicy>
 
+    class PolicyConstraints :
+            PolicyCheck2<T_CreationPolicy, T_DistributionPolicy>
+    {};
 
-  /** Enforces constraints on policies or combinations of polices
-   * 
-   * Uses template specialization of PolicyChecker
-   */
-  template < 
-     typename T_CreationPolicy, 
-     typename T_DistributionPolicy, 
-     typename T_OOMPolicy, 
-     typename T_GetHeapPolicy,
-     typename T_AlignmentPolicy
-       >
+    /** Scatter and XMallocSIMD need the same pagesize!
+     *
+     * This constraint ensures that if the CreationPolicy "Scatter" and the
+     * DistributionPolicy "XMallocSIMD" are selected, they are configured to use
+     * the same value for their "pagesize"-parameter.
+     */
+    template<typename x, typename y, typename z>
+    class PolicyCheck2<
+        typename CreationPolicies::Scatter<x, y>,
+        typename DistributionPolicies::XMallocSIMD<z>>
+    {
+        static_assert(
+            x::pagesize == z::pagesize,
+            "Pagesize must be the same when combining Scatter and XMallocSIMD");
+    };
 
-  class PolicyConstraints:PolicyCheck2<T_CreationPolicy, T_DistributionPolicy>{
-
-  };
-
-
-  /** Scatter and XMallocSIMD need the same pagesize!
-   *
-   * This constraint ensures that if the CreationPolicy "Scatter" and the
-   * DistributionPolicy "XMallocSIMD" are selected, they are configured to use
-   * the same value for their "pagesize"-parameter.
-   */
-  template<typename x, typename y, typename z >
-  class PolicyCheck2<
-    typename CreationPolicies::Scatter<x,y>,
-    typename DistributionPolicies::XMallocSIMD<z> 
-  >{
-    static_assert(x::pagesize == z::pagesize, "Pagesize must be the same when combining Scatter and XMallocSIMD");
-  };
-
-}//namespace mallocMC
+} // namespace mallocMC

--- a/src/include/mallocMC/mallocMC_prefixes.hpp
+++ b/src/include/mallocMC/mallocMC_prefixes.hpp
@@ -32,4 +32,3 @@
 
 #define MAMC_HOST __host__
 #define MAMC_ACCELERATOR __device__
-

--- a/src/include/mallocMC/mallocMC_traits.hpp
+++ b/src/include/mallocMC/mallocMC_traits.hpp
@@ -28,10 +28,12 @@
 
 #pragma once
 
-namespace mallocMC{
-    template <class T_Allocator>
-    struct Traits{
-        static constexpr bool providesAvailableSlots = T_Allocator::CreationPolicy::providesAvailableSlots;
+namespace mallocMC
+{
+    template<class T_Allocator>
+    struct Traits
+    {
+        static constexpr bool providesAvailableSlots
+            = T_Allocator::CreationPolicy::providesAvailableSlots;
     };
-} //namespace mallocMC
-
+} // namespace mallocMC

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -39,196 +39,197 @@
 #include <intrin.h>
 #endif
 
+#include "mallocMC_prefixes.hpp"
+
 #include <cstdint>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 
-#include "mallocMC_prefixes.hpp"
-
 namespace CUDA
 {
-  class error : public std::runtime_error
-  {
-  private:
-    static std::string genErrorString(cudaError errorValue, const char* file, int line)
+    class error : public std::runtime_error
     {
-      std::ostringstream msg;
-      msg << file << '(' << line << "): error: " << cudaGetErrorString(errorValue);
-      return msg.str();
-    }
-  public:
-    error(cudaError errorValue, const char* file, int line)
-      : runtime_error(genErrorString(errorValue, file, line))
+    private:
+        static std::string
+        genErrorString(cudaError errorValue, const char * file, int line)
+        {
+            std::ostringstream msg;
+            msg << file << '(' << line
+                << "): error: " << cudaGetErrorString(errorValue);
+            return msg.str();
+        }
+
+    public:
+        error(cudaError errorValue, const char * file, int line) :
+                runtime_error(genErrorString(errorValue, file, line))
+        {}
+
+        explicit error(cudaError errorValue) :
+                runtime_error(cudaGetErrorString(errorValue))
+        {}
+
+        explicit error(const std::string & msg) : runtime_error(msg) {}
+    };
+
+    inline void checkError(cudaError errorValue, const char * file, int line)
     {
+        if(errorValue != cudaSuccess)
+            throw CUDA::error(errorValue, file, line);
     }
 
-    explicit error(cudaError errorValue)
-      : runtime_error(cudaGetErrorString(errorValue))
+    inline void checkError(const char * file, int line)
     {
+        checkError(cudaGetLastError(), file, line);
     }
 
-    explicit error(const std::string& msg)
-      : runtime_error(msg)
+    inline void checkError()
     {
+        cudaError errorValue = cudaGetLastError();
+        if(errorValue != cudaSuccess)
+            throw CUDA::error(errorValue);
     }
-  };
 
-  inline void checkError(cudaError errorValue, const char* file, int line)
-  {
-    if (errorValue != cudaSuccess)
-      throw CUDA::error(errorValue, file, line);
-  }
-
-  inline void checkError(const char* file, int line)
-  {
-    checkError(cudaGetLastError(), file, line);
-  }
-
-  inline void checkError()
-  {
-    cudaError errorValue = cudaGetLastError();
-    if (errorValue != cudaSuccess)
-      throw CUDA::error(errorValue);
-  }
-
-#define MALLOCMC_CUDA_CHECKED_CALL(call) CUDA::checkError(call, __FILE__, __LINE__)
+#define MALLOCMC_CUDA_CHECKED_CALL(call) \
+    CUDA::checkError(call, __FILE__, __LINE__)
 #define MALLOCMC_CUDA_CHECK_ERROR() CUDA::checkError(__FILE__, __LINE__)
-}  // namespace CUDA
+} // namespace CUDA
 
 namespace mallocMC
 {
-  template<int PSIZE>
-  class __PointerEquivalent
-  {
-  public:
-    using type = unsigned int;
-  };
-  template<>
-  class __PointerEquivalent<8>
-  {
-  public:
-    using type = unsigned long long;
-  };
+    template<int PSIZE>
+    class __PointerEquivalent
+    {
+    public:
+        using type = unsigned int;
+    };
+    template<>
+    class __PointerEquivalent<8>
+    {
+    public:
+        using type = unsigned long long;
+    };
 
-  using PointerEquivalent = mallocMC::__PointerEquivalent<sizeof(char*)>::type;
+    using PointerEquivalent
+        = mallocMC::__PointerEquivalent<sizeof(char *)>::type;
 
-  MAMC_ACCELERATOR inline std::uint32_t laneid()
-  {
-    std::uint32_t mylaneid;
-    asm("mov.u32 %0, %%laneid;" : "=r" (mylaneid));
-    return mylaneid;
-  }
+    MAMC_ACCELERATOR inline std::uint32_t laneid()
+    {
+        std::uint32_t mylaneid;
+        asm("mov.u32 %0, %%laneid;" : "=r"(mylaneid));
+        return mylaneid;
+    }
 
-  /** warp index within a multiprocessor
-   *
-   * Index of the warp within the multiprocessor at the moment of the query.
-   * The result is volatile and can be different with each query.
-   *
-   * @return current index of the warp
-   */
-  MAMC_ACCELERATOR inline std::uint32_t warpid()
-  {
-    std::uint32_t mywarpid;
-    asm("mov.u32 %0, %%warpid;" : "=r" (mywarpid));
-    return mywarpid;
-  }
+    /** warp index within a multiprocessor
+     *
+     * Index of the warp within the multiprocessor at the moment of the query.
+     * The result is volatile and can be different with each query.
+     *
+     * @return current index of the warp
+     */
+    MAMC_ACCELERATOR inline std::uint32_t warpid()
+    {
+        std::uint32_t mywarpid;
+        asm("mov.u32 %0, %%warpid;" : "=r"(mywarpid));
+        return mywarpid;
+    }
 
-  /** maximum number of warps on a multiprocessor
-   *
-   * @return maximum number of warps on a multiprocessor
-   */
-  MAMC_ACCELERATOR inline std::uint32_t nwarpid()
-  {
-    std::uint32_t mynwarpid;
-    asm("mov.u32 %0, %%nwarpid;" : "=r" (mynwarpid));
-    return mynwarpid;
-  }
+    /** maximum number of warps on a multiprocessor
+     *
+     * @return maximum number of warps on a multiprocessor
+     */
+    MAMC_ACCELERATOR inline std::uint32_t nwarpid()
+    {
+        std::uint32_t mynwarpid;
+        asm("mov.u32 %0, %%nwarpid;" : "=r"(mynwarpid));
+        return mynwarpid;
+    }
 
-  MAMC_ACCELERATOR inline std::uint32_t smid()
-  {
-    std::uint32_t mysmid;
-    asm("mov.u32 %0, %%smid;" : "=r" (mysmid));
-    return mysmid;
-  }
+    MAMC_ACCELERATOR inline std::uint32_t smid()
+    {
+        std::uint32_t mysmid;
+        asm("mov.u32 %0, %%smid;" : "=r"(mysmid));
+        return mysmid;
+    }
 
-  MAMC_ACCELERATOR inline std::uint32_t nsmid()
-  {
-    std::uint32_t mynsmid;
-    asm("mov.u32 %0, %%nsmid;" : "=r" (mynsmid));
-    return mynsmid;
-  }
-  MAMC_ACCELERATOR inline std::uint32_t lanemask()
-  {
-    std::uint32_t lanemask;
-    asm("mov.u32 %0, %%lanemask_eq;" : "=r" (lanemask));
-    return lanemask;
-  }
+    MAMC_ACCELERATOR inline std::uint32_t nsmid()
+    {
+        std::uint32_t mynsmid;
+        asm("mov.u32 %0, %%nsmid;" : "=r"(mynsmid));
+        return mynsmid;
+    }
+    MAMC_ACCELERATOR inline std::uint32_t lanemask()
+    {
+        std::uint32_t lanemask;
+        asm("mov.u32 %0, %%lanemask_eq;" : "=r"(lanemask));
+        return lanemask;
+    }
 
-  MAMC_ACCELERATOR inline std::uint32_t lanemask_le()
-  {
-    std::uint32_t lanemask;
-    asm("mov.u32 %0, %%lanemask_le;" : "=r" (lanemask));
-    return lanemask;
-  }
+    MAMC_ACCELERATOR inline std::uint32_t lanemask_le()
+    {
+        std::uint32_t lanemask;
+        asm("mov.u32 %0, %%lanemask_le;" : "=r"(lanemask));
+        return lanemask;
+    }
 
-  MAMC_ACCELERATOR inline std::uint32_t lanemask_lt()
-  {
-    std::uint32_t lanemask;
-    asm("mov.u32 %0, %%lanemask_lt;" : "=r" (lanemask));
-    return lanemask;
-  }
+    MAMC_ACCELERATOR inline std::uint32_t lanemask_lt()
+    {
+        std::uint32_t lanemask;
+        asm("mov.u32 %0, %%lanemask_lt;" : "=r"(lanemask));
+        return lanemask;
+    }
 
-  MAMC_ACCELERATOR inline std::uint32_t lanemask_ge()
-  {
-    std::uint32_t lanemask;
-    asm("mov.u32 %0, %%lanemask_ge;" : "=r" (lanemask));
-    return lanemask;
-  }
+    MAMC_ACCELERATOR inline std::uint32_t lanemask_ge()
+    {
+        std::uint32_t lanemask;
+        asm("mov.u32 %0, %%lanemask_ge;" : "=r"(lanemask));
+        return lanemask;
+    }
 
-  MAMC_ACCELERATOR inline std::uint32_t lanemask_gt()
-  {
-    std::uint32_t lanemask;
-    asm("mov.u32 %0, %%lanemask_gt;" : "=r" (lanemask));
-    return lanemask;
-  }
+    MAMC_ACCELERATOR inline std::uint32_t lanemask_gt()
+    {
+        std::uint32_t lanemask;
+        asm("mov.u32 %0, %%lanemask_gt;" : "=r"(lanemask));
+        return lanemask;
+    }
 
-  template<class T>
-  MAMC_HOST MAMC_ACCELERATOR inline T divup(T a, T b) { return (a + b - 1) / b; }
+    template<class T>
+    MAMC_HOST MAMC_ACCELERATOR inline T divup(T a, T b)
+    {
+        return (a + b - 1) / b;
+    }
 
-  /** the maximal number threads per block
-   *
-   * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities
-   */
-  struct MaxThreadsPerBlock
-  {
-    // valid for sm_2.X - sm_7.5
-    static constexpr uint32_t value = 1024;
-  };
+    /** the maximal number threads per block
+     *
+     * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities
+     */
+    struct MaxThreadsPerBlock
+    {
+        // valid for sm_2.X - sm_7.5
+        static constexpr uint32_t value = 1024;
+    };
 
-  /** number of threads within a warp
-   *
-   * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities
-   */
-  struct WarpSize
-  {
-    // valid for sm_2.X - sm_7.5
-    static constexpr uint32_t value = 32;
-  };
+    /** number of threads within a warp
+     *
+     * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities
+     */
+    struct WarpSize
+    {
+        // valid for sm_2.X - sm_7.5
+        static constexpr uint32_t value = 32;
+    };
 
-  /** warp id within a cuda block
-   *
-   * The id is constant over the lifetime of the thread.
-   * The id is not equal to warpid().
-   *
-   * @return warp id within the block
-   */
-  MAMC_ACCELERATOR inline std::uint32_t warpid_withinblock()
-  {
-    return (
-      threadIdx.z * blockDim.y * blockDim.x +
-      threadIdx.y * blockDim.x +
-      threadIdx.x
-    ) / WarpSize::value;
-  }
-}  // namespace mallocMC
+    /** warp id within a cuda block
+     *
+     * The id is constant over the lifetime of the thread.
+     * The id is not equal to warpid().
+     *
+     * @return warp id within the block
+     */
+    MAMC_ACCELERATOR inline std::uint32_t warpid_withinblock()
+    {
+        return (threadIdx.z * blockDim.y * blockDim.x + threadIdx.y * blockDim.x
+                + threadIdx.x)
+            / WarpSize::value;
+    }
+} // namespace mallocMC

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -52,7 +52,8 @@ namespace CUDA
     {
     private:
         static auto
-        genErrorString(cudaError errorValue, const char * file, int line) -> std::string
+        genErrorString(cudaError errorValue, const char * file, int line)
+            -> std::string
         {
             std::ostringstream msg;
             msg << file << '(' << line

--- a/src/include/mallocMC/mallocMC_utils.hpp
+++ b/src/include/mallocMC/mallocMC_utils.hpp
@@ -51,8 +51,8 @@ namespace CUDA
     class error : public std::runtime_error
     {
     private:
-        static std::string
-        genErrorString(cudaError errorValue, const char * file, int line)
+        static auto
+        genErrorString(cudaError errorValue, const char * file, int line) -> std::string
         {
             std::ostringstream msg;
             msg << file << '(' << line
@@ -113,7 +113,7 @@ namespace mallocMC
     using PointerEquivalent
         = mallocMC::__PointerEquivalent<sizeof(char *)>::type;
 
-    MAMC_ACCELERATOR inline std::uint32_t laneid()
+    MAMC_ACCELERATOR inline auto laneid() -> std::uint32_t
     {
         std::uint32_t mylaneid;
         asm("mov.u32 %0, %%laneid;" : "=r"(mylaneid));
@@ -127,7 +127,7 @@ namespace mallocMC
      *
      * @return current index of the warp
      */
-    MAMC_ACCELERATOR inline std::uint32_t warpid()
+    MAMC_ACCELERATOR inline auto warpid() -> std::uint32_t
     {
         std::uint32_t mywarpid;
         asm("mov.u32 %0, %%warpid;" : "=r"(mywarpid));
@@ -138,55 +138,55 @@ namespace mallocMC
      *
      * @return maximum number of warps on a multiprocessor
      */
-    MAMC_ACCELERATOR inline std::uint32_t nwarpid()
+    MAMC_ACCELERATOR inline auto nwarpid() -> std::uint32_t
     {
         std::uint32_t mynwarpid;
         asm("mov.u32 %0, %%nwarpid;" : "=r"(mynwarpid));
         return mynwarpid;
     }
 
-    MAMC_ACCELERATOR inline std::uint32_t smid()
+    MAMC_ACCELERATOR inline auto smid() -> std::uint32_t
     {
         std::uint32_t mysmid;
         asm("mov.u32 %0, %%smid;" : "=r"(mysmid));
         return mysmid;
     }
 
-    MAMC_ACCELERATOR inline std::uint32_t nsmid()
+    MAMC_ACCELERATOR inline auto nsmid() -> std::uint32_t
     {
         std::uint32_t mynsmid;
         asm("mov.u32 %0, %%nsmid;" : "=r"(mynsmid));
         return mynsmid;
     }
-    MAMC_ACCELERATOR inline std::uint32_t lanemask()
+    MAMC_ACCELERATOR inline auto lanemask() -> std::uint32_t
     {
         std::uint32_t lanemask;
         asm("mov.u32 %0, %%lanemask_eq;" : "=r"(lanemask));
         return lanemask;
     }
 
-    MAMC_ACCELERATOR inline std::uint32_t lanemask_le()
+    MAMC_ACCELERATOR inline auto lanemask_le() -> std::uint32_t
     {
         std::uint32_t lanemask;
         asm("mov.u32 %0, %%lanemask_le;" : "=r"(lanemask));
         return lanemask;
     }
 
-    MAMC_ACCELERATOR inline std::uint32_t lanemask_lt()
+    MAMC_ACCELERATOR inline auto lanemask_lt() -> std::uint32_t
     {
         std::uint32_t lanemask;
         asm("mov.u32 %0, %%lanemask_lt;" : "=r"(lanemask));
         return lanemask;
     }
 
-    MAMC_ACCELERATOR inline std::uint32_t lanemask_ge()
+    MAMC_ACCELERATOR inline auto lanemask_ge() -> std::uint32_t
     {
         std::uint32_t lanemask;
         asm("mov.u32 %0, %%lanemask_ge;" : "=r"(lanemask));
         return lanemask;
     }
 
-    MAMC_ACCELERATOR inline std::uint32_t lanemask_gt()
+    MAMC_ACCELERATOR inline auto lanemask_gt() -> std::uint32_t
     {
         std::uint32_t lanemask;
         asm("mov.u32 %0, %%lanemask_gt;" : "=r"(lanemask));
@@ -194,7 +194,7 @@ namespace mallocMC
     }
 
     template<class T>
-    MAMC_HOST MAMC_ACCELERATOR inline T divup(T a, T b)
+    MAMC_HOST MAMC_ACCELERATOR inline auto divup(T a, T b) -> T
     {
         return (a + b - 1) / b;
     }
@@ -226,7 +226,7 @@ namespace mallocMC
      *
      * @return warp id within the block
      */
-    MAMC_ACCELERATOR inline std::uint32_t warpid_withinblock()
+    MAMC_ACCELERATOR inline auto warpid_withinblock() -> std::uint32_t
     {
         return (threadIdx.z * blockDim.y * blockDim.x + threadIdx.y * blockDim.x
                 + threadIdx.x)

--- a/src/include/mallocMC/oOMPolicies/BadAllocException.hpp
+++ b/src/include/mallocMC/oOMPolicies/BadAllocException.hpp
@@ -27,19 +27,21 @@
 
 #pragma once
 
-namespace mallocMC{
-namespace OOMPolicies{
+namespace mallocMC
+{
+    namespace OOMPolicies
+    {
+        /**
+         * @brief Throws a std::bad_alloc exception on OutOfMemory
+         *
+         * This OOMPolicy will throw a std::bad_alloc exception, if the
+         * accelerator supports it. Currently, Nvidia CUDA does not support any
+         * form of exception handling, therefore handleOOM() does not have any
+         * effect on these accelerators. Using this policy on other types of
+         * accelerators that do not support exceptions results in undefined
+         * behaviour.
+         */
+        struct BadAllocException;
 
-  /**
-   * @brief Throws a std::bad_alloc exception on OutOfMemory
-   *
-   * This OOMPolicy will throw a std::bad_alloc exception, if the accelerator
-   * supports it. Currently, Nvidia CUDA does not support any form of exception
-   * handling, therefore handleOOM() does not have any effect on these
-   * accelerators. Using this policy on other types of accelerators that do not
-   * support exceptions results in undefined behaviour.
-   */
-  struct BadAllocException;
-
-} //namespace OOMPolicies
-} //namespace mallocMC
+    } // namespace OOMPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
@@ -40,7 +40,7 @@ namespace mallocMC
         struct BadAllocException
         {
             MAMC_ACCELERATOR
-            static void * handleOOM(void * mem)
+            static auto handleOOM(void * mem) -> void *
             {
 #ifdef __CUDACC__
 //#if __CUDA_ARCH__ < 350
@@ -57,7 +57,7 @@ namespace mallocMC
                 return mem;
             }
 
-            static std::string classname()
+            static auto classname() -> std::string
             {
                 return "BadAllocException";
             }

--- a/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
@@ -27,19 +27,21 @@
 
 #pragma once
 
-#include <cassert>
-#include <string>
-
 #include "../mallocMC_prefixes.hpp"
 #include "BadAllocException.hpp"
 
-namespace mallocMC{
-namespace OOMPolicies{
+#include <cassert>
+#include <string>
 
-  struct BadAllocException
-  {
-    MAMC_ACCELERATOR
-    static void* handleOOM(void* mem){
+namespace mallocMC
+{
+    namespace OOMPolicies
+    {
+        struct BadAllocException
+        {
+            MAMC_ACCELERATOR
+            static void * handleOOM(void * mem)
+            {
 #ifdef __CUDACC__
 //#if __CUDA_ARCH__ < 350
 #define PM_EXCEPTIONS_NOT_SUPPORTED_HERE
@@ -48,17 +50,18 @@ namespace OOMPolicies{
 
 #ifdef PM_EXCEPTIONS_NOT_SUPPORTED_HERE
 #undef PM_EXCEPTIONS_NOT_SUPPORTED_HERE
-      assert(false);
+                assert(false);
 #else
-      throw std::bad_alloc{};
+                throw std::bad_alloc{};
 #endif
-      return mem;
-    }
+                return mem;
+            }
 
-    static std::string classname(){
-      return "BadAllocException";
-    }
-  };
+            static std::string classname()
+            {
+                return "BadAllocException";
+            }
+        };
 
-} //namespace OOMPolicies
-} //namespace mallocMC
+    } // namespace OOMPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/oOMPolicies/ReturnNull.hpp
+++ b/src/include/mallocMC/oOMPolicies/ReturnNull.hpp
@@ -27,15 +27,16 @@
 
 #pragma once
 
-namespace mallocMC{
-namespace OOMPolicies{
+namespace mallocMC
+{
+    namespace OOMPolicies
+    {
+        /**
+         * @brief Returns a nullptr pointer on OutOfMemory conditions
+         *
+         * This OOMPolicy will return nullptr, if handleOOM() is called.
+         */
+        class ReturnNull;
 
-  /**
-   * @brief Returns a nullptr pointer on OutOfMemory conditions
-   *
-   * This OOMPolicy will return nullptr, if handleOOM() is called.
-   */
-  class ReturnNull;
-    
-} //namespace OOMPolicies
-} //namespace mallocMC
+    } // namespace OOMPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
@@ -40,12 +40,12 @@ namespace mallocMC
         {
         public:
             MAMC_ACCELERATOR
-            static void * handleOOM(void * mem)
+            static auto handleOOM(void * mem) -> void *
             {
                 return nullptr;
             }
 
-            static std::string classname()
+            static auto classname() -> std::string
             {
                 return "ReturnNull";
             }

--- a/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
@@ -27,26 +27,29 @@
 
 #pragma once
 
-#include <string>
-
 #include "../mallocMC_prefixes.hpp"
 #include "ReturnNull.hpp"
 
-namespace mallocMC{
-namespace OOMPolicies{
+#include <string>
 
-  class ReturnNull
-  {
-    public:
-      MAMC_ACCELERATOR
-      static void* handleOOM(void* mem){
-        return nullptr;
-      }
+namespace mallocMC
+{
+    namespace OOMPolicies
+    {
+        class ReturnNull
+        {
+        public:
+            MAMC_ACCELERATOR
+            static void * handleOOM(void * mem)
+            {
+                return nullptr;
+            }
 
-      static std::string classname(){
-        return "ReturnNull";
-      }
-  };
+            static std::string classname()
+            {
+                return "ReturnNull";
+            }
+        };
 
-} //namespace OOMPolicies
-} //namespace mallocMC
+    } // namespace OOMPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/reservePoolPolicies/CudaSetLimits.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/CudaSetLimits.hpp
@@ -27,18 +27,19 @@
 
 #pragma once
 
-namespace mallocMC{
-namespace ReservePoolPolicies{
+namespace mallocMC
+{
+    namespace ReservePoolPolicies
+    {
+        /**
+         * @brief set CUDA internal heap for device-side malloc calls
+         *
+         * This ReservePoolPolicy is intended for use with CUDA capable
+         * accelerators that support at least compute capability 2.0. It should
+         * be used in conjunction with a CreationPolicy that actually requires
+         * the CUDA-internal heap to be sized by calls to cudaDeviceSetLimit()
+         */
+        struct CudaSetLimits;
 
-  /**
-   * @brief set CUDA internal heap for device-side malloc calls
-   *
-   * This ReservePoolPolicy is intended for use with CUDA capable accelerators
-   * that support at least compute capability 2.0. It should be used in
-   * conjunction with a CreationPolicy that actually requires the CUDA-internal
-   * heap to be sized by calls to cudaDeviceSetLimit()
-   */
-  struct CudaSetLimits;
-
-} //namespace ReservePoolPolicies
-} //namespace mallocMC
+    } // namespace ReservePoolPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/reservePoolPolicies/CudaSetLimits_impl.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/CudaSetLimits_impl.hpp
@@ -38,7 +38,7 @@ namespace mallocMC
     {
         struct CudaSetLimits
         {
-            static void * setMemPool(size_t memsize)
+            static auto setMemPool(size_t memsize) -> void *
             {
                 cudaDeviceSetLimit(cudaLimitMallocHeapSize, memsize);
                 return nullptr;
@@ -49,7 +49,7 @@ namespace mallocMC
                 cudaDeviceSetLimit(cudaLimitMallocHeapSize, 8192U);
             }
 
-            static std::string classname()
+            static auto classname() -> std::string
             {
                 return "CudaSetLimits";
             }

--- a/src/include/mallocMC/reservePoolPolicies/CudaSetLimits_impl.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/CudaSetLimits_impl.hpp
@@ -27,29 +27,33 @@
 
 #pragma once
 
+#include "CudaSetLimits.hpp"
+
 #include <cuda_runtime_api.h>
 #include <string>
 
-#include "CudaSetLimits.hpp"
+namespace mallocMC
+{
+    namespace ReservePoolPolicies
+    {
+        struct CudaSetLimits
+        {
+            static void * setMemPool(size_t memsize)
+            {
+                cudaDeviceSetLimit(cudaLimitMallocHeapSize, memsize);
+                return nullptr;
+            }
 
-namespace mallocMC{
-namespace ReservePoolPolicies{
+            static void resetMemPool(void * p = nullptr)
+            {
+                cudaDeviceSetLimit(cudaLimitMallocHeapSize, 8192U);
+            }
 
-  struct CudaSetLimits{
-    static void* setMemPool(size_t memsize){
-      cudaDeviceSetLimit(cudaLimitMallocHeapSize, memsize);
-      return nullptr;
-    }
+            static std::string classname()
+            {
+                return "CudaSetLimits";
+            }
+        };
 
-    static void resetMemPool(void *p=nullptr){
-      cudaDeviceSetLimit(cudaLimitMallocHeapSize, 8192U);
-    }
-
-    static std::string classname(){
-      return "CudaSetLimits";
-    }
-
-  };
-
-} //namespace ReservePoolPolicies
-} //namespace mallocMC
+    } // namespace ReservePoolPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc.hpp
@@ -27,18 +27,19 @@
 
 #pragma once
 
-namespace mallocMC{
-namespace ReservePoolPolicies{
+namespace mallocMC
+{
+    namespace ReservePoolPolicies
+    {
+        /**
+         * @brief creates/allocates a fixed memory pool on the accelerator
+         *
+         * This ReservePoolPolicy will create a memory pool of a fixed size on
+         * the accelerator by using a host-side call to cudaMalloc(). The pool
+         * is later freed through cudaFree(). This can only be used with
+         * accelerators that support CUDA and compute capability 2.0 or higher.
+         */
+        struct SimpleCudaMalloc;
 
-  /**
-   * @brief creates/allocates a fixed memory pool on the accelerator
-   *
-   * This ReservePoolPolicy will create a memory pool of a fixed size on the
-   * accelerator by using a host-side call to cudaMalloc(). The pool is later
-   * freed through cudaFree(). This can only be used with accelerators that
-   * support CUDA and compute capability 2.0 or higher.
-   */
-  struct SimpleCudaMalloc;
-
-} //namespace ReservePoolPolicies
-} //namespace mallocMC
+    } // namespace ReservePoolPolicies
+} // namespace mallocMC

--- a/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
@@ -38,7 +38,7 @@ namespace mallocMC
     {
         struct SimpleCudaMalloc
         {
-            static void * setMemPool(size_t memsize)
+            static auto setMemPool(size_t memsize) -> void *
             {
                 void * pool = nullptr;
                 MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc(&pool, memsize));
@@ -50,7 +50,7 @@ namespace mallocMC
                 MALLOCMC_CUDA_CHECKED_CALL(cudaFree(p));
             }
 
-            static std::string classname()
+            static auto classname() -> std::string
             {
                 return "SimpleCudaMalloc";
             }

--- a/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
+++ b/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
@@ -27,31 +27,34 @@
 
 #pragma once
 
-#include <string>
-
 #include "../mallocMC_utils.hpp"
-
 #include "SimpleCudaMalloc.hpp"
 
-namespace mallocMC{
-namespace ReservePoolPolicies{
+#include <string>
 
-  struct SimpleCudaMalloc{
-    static void* setMemPool(size_t memsize){
-      void* pool = nullptr;
-      MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc(&pool, memsize));
-      return pool;
-    }
+namespace mallocMC
+{
+    namespace ReservePoolPolicies
+    {
+        struct SimpleCudaMalloc
+        {
+            static void * setMemPool(size_t memsize)
+            {
+                void * pool = nullptr;
+                MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc(&pool, memsize));
+                return pool;
+            }
 
-    static void resetMemPool(void* p){
-      MALLOCMC_CUDA_CHECKED_CALL(cudaFree(p));
-    }
+            static void resetMemPool(void * p)
+            {
+                MALLOCMC_CUDA_CHECKED_CALL(cudaFree(p));
+            }
 
-    static std::string classname(){
-      return "SimpleCudaMalloc";
-    }
+            static std::string classname()
+            {
+                return "SimpleCudaMalloc";
+            }
+        };
 
-  };
-
-} //namespace ReservePoolPolicies
-} //namespace mallocMC
+    } // namespace ReservePoolPolicies
+} // namespace mallocMC

--- a/tests/verify_heap.cu
+++ b/tests/verify_heap.cu
@@ -26,30 +26,37 @@
   THE SOFTWARE.
 */
 
-
 // get a CUDA error and print it nicely
-#define CUDA_CHECK(cmd) {cudaError_t error = cmd; \
-  if(error!=cudaSuccess){\
-    printf("<%s>:%i ",__FILE__,__LINE__);\
-    printf("[CUDA] Error: %s\n", cudaGetErrorString(error));}}
+#define CUDA_CHECK(cmd) \
+    { \
+        cudaError_t error = cmd; \
+        if(error != cudaSuccess) \
+        { \
+            printf("<%s>:%i ", __FILE__, __LINE__); \
+            printf("[CUDA] Error: %s\n", cudaGetErrorString(error)); \
+        } \
+    }
 
 // start kernel, wait for finish and check errors
-#define CUDA_CHECK_KERNEL_SYNC(...) __VA_ARGS__;CUDA_CHECK(cudaDeviceSynchronize())
+#define CUDA_CHECK_KERNEL_SYNC(...) \
+    __VA_ARGS__; \
+    CUDA_CHECK(cudaDeviceSynchronize())
 
 // each pointer in the datastructure will point to this many
 // elements of type allocElem_t
 constexpr auto ELEMS_PER_SLOT = 750;
 
+#include <cstdio>
 #include <cuda.h>
 #include <iostream>
-#include <cstdio>
+#include <sstream>
 #include <typeinfo>
 #include <vector>
-#include <sstream>
 
-//include the Heap with the arguments given in the config
-#include <mallocMC/mallocMC_utils.hpp>
+// include the Heap with the arguments given in the config
 #include "verify_heap_config.hpp"
+
+#include <mallocMC/mallocMC_utils.hpp>
 
 // global variable for verbosity, might change due to user input '--verbose'
 bool verbose = false;
@@ -57,27 +64,37 @@ bool verbose = false;
 // the type of the elements to allocate
 using allocElem_t = unsigned long long;
 
-bool run_heap_verification(const size_t, const unsigned, const unsigned, const bool);
-void parse_cmdline(const int, char**, size_t*, unsigned*, unsigned*, bool*);
-void print_help(char**);
-
+bool run_heap_verification(
+    const size_t,
+    const unsigned,
+    const unsigned,
+    const bool);
+void parse_cmdline(
+    const int,
+    char **,
+    size_t *,
+    unsigned *,
+    unsigned *,
+    bool *);
+void print_help(char **);
 
 // used to create an empty stream for non-verbose output
-struct nullstream : std::ostream {
-  nullstream() : std::ostream(0) { }
+struct nullstream : std::ostream
+{
+    nullstream() : std::ostream(0) {}
 };
 
 // uses global verbosity to switch between std::cout and a nullptr-output
-std::ostream& dout() {
-  static nullstream n;
-  return verbose ? std::cout : n;
+std::ostream & dout()
+{
+    static nullstream n;
+    return verbose ? std::cout : n;
 }
 
 // define some defaults
 static constexpr unsigned threads_default = 128;
-static constexpr unsigned blocks_default  = 64;
-static constexpr size_t heapInMB_default  = 1024; // 1GB
-
+static constexpr unsigned blocks_default = 64;
+static constexpr size_t heapInMB_default = 1024; // 1GB
 
 /**
  * will do a basic verification of scatterAlloc.
@@ -88,41 +105,50 @@ static constexpr size_t heapInMB_default  = 1024; // 1GB
  * @return will return 0 if the verification was successful,
  *         otherwise returns 1
  */
-int main(int argc, char** argv){
-  bool correct          = false;
-  bool machine_readable = false;
-  size_t heapInMB       = heapInMB_default;
-  unsigned threads      = threads_default;
-  unsigned blocks       = blocks_default;
+int main(int argc, char ** argv)
+{
+    bool correct = false;
+    bool machine_readable = false;
+    size_t heapInMB = heapInMB_default;
+    unsigned threads = threads_default;
+    unsigned blocks = blocks_default;
 
-  parse_cmdline(argc, argv, &heapInMB, &threads, &blocks, &machine_readable);
+    parse_cmdline(argc, argv, &heapInMB, &threads, &blocks, &machine_readable);
 
-  int computeCapabilityMajor = 0;
-  cudaDeviceGetAttribute(&computeCapabilityMajor, cudaDevAttrComputeCapabilityMajor, 0);
-  int computeCapabilityMinor = 0;
-  cudaDeviceGetAttribute(&computeCapabilityMinor, cudaDevAttrComputeCapabilityMinor, 0);
+    int computeCapabilityMajor = 0;
+    cudaDeviceGetAttribute(
+        &computeCapabilityMajor, cudaDevAttrComputeCapabilityMajor, 0);
+    int computeCapabilityMinor = 0;
+    cudaDeviceGetAttribute(
+        &computeCapabilityMinor, cudaDevAttrComputeCapabilityMinor, 0);
 
-  if( computeCapabilityMajor < 2 ) {
-    std::cerr << "Error: Compute Capability >= 2.0 required. (is ";
-    std::cerr << computeCapabilityMajor << "."<< computeCapabilityMinor << ")\n";
-    return 1;
-  }
-
-  cudaSetDevice(0);
-  correct = run_heap_verification(heapInMB, threads, blocks, machine_readable);
-  cudaDeviceReset();
-
-  if(!machine_readable || verbose){
-    if(correct){
-      std::cout << "\033[0;32mverification successful ✔\033[0m\n";
-      return 0;
-    }else{
-      std::cerr << "\033[0;31mverification failed\033[0m\n";
-      return 1;
+    if(computeCapabilityMajor < 2)
+    {
+        std::cerr << "Error: Compute Capability >= 2.0 required. (is ";
+        std::cerr << computeCapabilityMajor << "." << computeCapabilityMinor
+                  << ")\n";
+        return 1;
     }
-  }
-}
 
+    cudaSetDevice(0);
+    correct
+        = run_heap_verification(heapInMB, threads, blocks, machine_readable);
+    cudaDeviceReset();
+
+    if(!machine_readable || verbose)
+    {
+        if(correct)
+        {
+            std::cout << "\033[0;32mverification successful ✔\033[0m\n";
+            return 0;
+        }
+        else
+        {
+            std::cerr << "\033[0;31mverification failed\033[0m\n";
+            return 1;
+        }
+    }
+}
 
 /**
  * will parse command line arguments
@@ -137,97 +163,105 @@ int main(int argc, char** argv){
  */
 void parse_cmdline(
     const int argc,
-    char**argv,
-    size_t *heapInMB,
-    unsigned *threads,
-    unsigned *blocks,
-    bool *machine_readable
-    ){
+    char ** argv,
+    size_t * heapInMB,
+    unsigned * threads,
+    unsigned * blocks,
+    bool * machine_readable)
+{
+    std::vector<std::pair<std::string, std::string>> parameters;
 
-  std::vector<std::pair<std::string, std::string> > parameters;
-
-  // Parse Commandline, tokens are shaped like ARG=PARAM or ARG
-  // This requires to use '=', if you want to supply a value with a parameter
-  for (int i = 1; i < argc; ++i) {
-    char* pos = strtok(argv[i], "=");
-    std::pair < std::string, std::string > p(std::string(pos), std::string(""));
-    pos = strtok(nullptr, "=");
-    if (pos != nullptr) {
-      p.second = std::string(pos);
-    }
-    parameters.push_back(p);
-  }
-
-  // go through all parameters that were found
-  for (unsigned i = 0; i < parameters.size(); ++i) {
-    std::pair < std::string, std::string > p = parameters.at(i);
-
-    if (p.first == "-v" || p.first == "--verbose") {
-      verbose = true;
+    // Parse Commandline, tokens are shaped like ARG=PARAM or ARG
+    // This requires to use '=', if you want to supply a value with a parameter
+    for(int i = 1; i < argc; ++i)
+    {
+        char * pos = strtok(argv[i], "=");
+        std::pair<std::string, std::string> p(
+            std::string(pos), std::string(""));
+        pos = strtok(nullptr, "=");
+        if(pos != nullptr)
+        {
+            p.second = std::string(pos);
+        }
+        parameters.push_back(p);
     }
 
-    if (p.first == "--threads") {
-      *threads = atoi(p.second.c_str());
-    }
+    // go through all parameters that were found
+    for(unsigned i = 0; i < parameters.size(); ++i)
+    {
+        std::pair<std::string, std::string> p = parameters.at(i);
 
-    if (p.first == "--blocks") {
-      *blocks = atoi(p.second.c_str());
-    }
+        if(p.first == "-v" || p.first == "--verbose")
+        {
+            verbose = true;
+        }
 
-    if(p.first == "--heapsize") {
-      *heapInMB = size_t(atoi(p.second.c_str()));
-    }
+        if(p.first == "--threads")
+        {
+            *threads = atoi(p.second.c_str());
+        }
 
-    if(p.first == "-h" || p.first == "--help"){
-      print_help(argv);
-      exit(0);
-    }
+        if(p.first == "--blocks")
+        {
+            *blocks = atoi(p.second.c_str());
+        }
 
-    if(p.first == "-m" || p.first == "--machine_readable"){
-      *machine_readable = true;
+        if(p.first == "--heapsize")
+        {
+            *heapInMB = size_t(atoi(p.second.c_str()));
+        }
+
+        if(p.first == "-h" || p.first == "--help")
+        {
+            print_help(argv);
+            exit(0);
+        }
+
+        if(p.first == "-m" || p.first == "--machine_readable")
+        {
+            *machine_readable = true;
+        }
     }
-  }
 }
-
 
 /**
  * prints a helpful message about program use
  *
  * @param argv the argv-parameter from main, used to find the program name
  */
-void print_help(char** argv){
-  std::stringstream s;
+void print_help(char ** argv)
+{
+    std::stringstream s;
 
-  s << "SYNOPSIS:"                                              << '\n';
-  s << argv[0] << " [OPTIONS]"                                  << '\n';
-  s << ""                                                       << '\n';
-  s << "OPTIONS:"                                               << '\n';
-  s << "  -h, --help"                                           << '\n';
-  s << "    Print this help message and exit"                   << '\n';
-  s << ""                                                       << '\n';
-  s << "  -v, --verbose"                                        << '\n';
-  s << "    Print information about parameters and progress"    << '\n';
-  s << ""                                                       << '\n';
-  s << "  -m, --machine_readable"                               << '\n';
-  s << "    Print all relevant parameters as CSV. This will"    << '\n';
-  s << "    suppress all other output unless explicitly"        << '\n';
-  s << "    requested with --verbose or -v"                     << '\n';
-  s << ""                                                       << '\n';
-  s << "  --threads=N"                                          << '\n';
-  s << "    Set the number of threads per block (default "             ;
-  s <<                               threads_default << "128)"  << '\n';
-  s << ""                                                       << '\n';
-  s << "  --blocks=N"                                           << '\n';
-  s << "    Set the number of blocks in the grid (default "            ;
-  s <<                                   blocks_default << ")"  << '\n';
-  s << ""                                                       << '\n';
-  s << "  --heapsize=N"                                         << '\n';
-  s << "    Set the heapsize to N Megabyte (default "                  ;
-  s <<                         heapInMB_default << "1024)"      << '\n';
+    s << "SYNOPSIS:" << '\n';
+    s << argv[0] << " [OPTIONS]" << '\n';
+    s << "" << '\n';
+    s << "OPTIONS:" << '\n';
+    s << "  -h, --help" << '\n';
+    s << "    Print this help message and exit" << '\n';
+    s << "" << '\n';
+    s << "  -v, --verbose" << '\n';
+    s << "    Print information about parameters and progress" << '\n';
+    s << "" << '\n';
+    s << "  -m, --machine_readable" << '\n';
+    s << "    Print all relevant parameters as CSV. This will" << '\n';
+    s << "    suppress all other output unless explicitly" << '\n';
+    s << "    requested with --verbose or -v" << '\n';
+    s << "" << '\n';
+    s << "  --threads=N" << '\n';
+    s << "    Set the number of threads per block (default ";
+    s << threads_default << "128)" << '\n';
+    s << "" << '\n';
+    s << "  --blocks=N" << '\n';
+    s << "    Set the number of blocks in the grid (default ";
+    s << blocks_default << ")" << '\n';
+    s << "" << '\n';
+    s << "  --heapsize=N" << '\n';
+    s << "    Set the heapsize to N Megabyte (default ";
+    s << heapInMB_default << "1024)" << '\n';
 
-  std::cout << s.str() << std::flush;
+    std::cout << s.str() << std::flush;
 }
-
 
 /**
  * checks validity of memory for each single cell
@@ -248,30 +282,36 @@ void print_help(char** argv){
  *        Will change to 0, if there was a value that didn't match
  */
 __global__ void check_content(
-    allocElem_t** data,
-    unsigned long long *counter,
-    unsigned long long* globalSum,
+    allocElem_t ** data,
+    unsigned long long * counter,
+    unsigned long long * globalSum,
     const size_t nSlots,
-    int* correct
-    ){
-
-  unsigned long long sum=0;
-  while(true){
-    const size_t pos = atomicAdd(counter,1);
-    if(pos >= nSlots){break;}
-    const size_t offset = pos*ELEMS_PER_SLOT;
-    for(size_t i=0;i<ELEMS_PER_SLOT;++i){
-      if (static_cast<allocElem_t>(data[pos][i]) != static_cast<allocElem_t>(offset+i)){
-        //printf("\nError in Kernel: data[%llu][%llu] is %#010x (should be %#010x)\n",
-        //    pos,i,static_cast<allocElem_t>(data[pos][i]),allocElem_t(offset+i));
-        atomicAnd(correct,0);
-      }
-      sum += static_cast<unsigned long long>(data[pos][i]);
+    int * correct)
+{
+    unsigned long long sum = 0;
+    while(true)
+    {
+        const size_t pos = atomicAdd(counter, 1);
+        if(pos >= nSlots)
+        {
+            break;
+        }
+        const size_t offset = pos * ELEMS_PER_SLOT;
+        for(size_t i = 0; i < ELEMS_PER_SLOT; ++i)
+        {
+            if(static_cast<allocElem_t>(data[pos][i])
+               != static_cast<allocElem_t>(offset + i))
+            {
+                // printf("\nError in Kernel: data[%llu][%llu] is %#010x (should
+                // be %#010x)\n",
+                //    pos,i,static_cast<allocElem_t>(data[pos][i]),allocElem_t(offset+i));
+                atomicAnd(correct, 0);
+            }
+            sum += static_cast<unsigned long long>(data[pos][i]);
+        }
     }
-  }
-  atomicAdd(globalSum,sum);
+    atomicAdd(globalSum, sum);
 }
-
 
 /**
  * checks validity of memory for each single cell
@@ -288,26 +328,31 @@ __global__ void check_content(
  *        Will change to 0, if there was a value that didn't match
  */
 __global__ void check_content_fast(
-    allocElem_t** data,
-    unsigned long long *counter,
+    allocElem_t ** data,
+    unsigned long long * counter,
     const size_t nSlots,
-    int* correct
-    ){
-
-  int c = 1;
-  while(true){
-    size_t pos = atomicAdd(counter,1);
-    if(pos >= nSlots){break;}
-    const size_t offset = pos*ELEMS_PER_SLOT;
-    for(size_t i=0;i<ELEMS_PER_SLOT;++i){
-      if (static_cast<allocElem_t>(data[pos][i]) != static_cast<allocElem_t>(offset+i)){
-        c=0;
-      }
+    int * correct)
+{
+    int c = 1;
+    while(true)
+    {
+        size_t pos = atomicAdd(counter, 1);
+        if(pos >= nSlots)
+        {
+            break;
+        }
+        const size_t offset = pos * ELEMS_PER_SLOT;
+        for(size_t i = 0; i < ELEMS_PER_SLOT; ++i)
+        {
+            if(static_cast<allocElem_t>(data[pos][i])
+               != static_cast<allocElem_t>(offset + i))
+            {
+                c = 0;
+            }
+        }
     }
-  }
-  atomicAnd(correct,c);
+    atomicAnd(correct, c);
 }
-
 
 /**
  * allocate a lot of small arrays and fill them
@@ -323,29 +368,31 @@ __global__ void check_content_fast(
  *        allocated structures (for verification purposes)
  */
 __global__ void allocAll(
-    allocElem_t** data,
-    unsigned long long* counter,
-    unsigned long long* globalSum,
-    ScatterAllocator::AllocatorHandle mMC
-    ){
+    allocElem_t ** data,
+    unsigned long long * counter,
+    unsigned long long * globalSum,
+    ScatterAllocator::AllocatorHandle mMC)
+{
+    unsigned long long sum = 0;
+    while(true)
+    {
+        allocElem_t * p
+            = (allocElem_t *)mMC.malloc(sizeof(allocElem_t) * ELEMS_PER_SLOT);
+        if(p == nullptr)
+            break;
 
-  unsigned long long sum=0;
-  while(true){
-    allocElem_t* p = (allocElem_t*) mMC.malloc(sizeof(allocElem_t) * ELEMS_PER_SLOT);
-    if(p == nullptr) break;
-
-    size_t pos = atomicAdd(counter,1);
-    const size_t offset = pos*ELEMS_PER_SLOT;
-    for(size_t i=0;i<ELEMS_PER_SLOT;++i){
-      p[i] = static_cast<allocElem_t>(offset + i);
-      sum += static_cast<unsigned long long>(p[i]);
+        size_t pos = atomicAdd(counter, 1);
+        const size_t offset = pos * ELEMS_PER_SLOT;
+        for(size_t i = 0; i < ELEMS_PER_SLOT; ++i)
+        {
+            p[i] = static_cast<allocElem_t>(offset + i);
+            sum += static_cast<unsigned long long>(p[i]);
+        }
+        data[pos] = p;
     }
-    data[pos] = p;
-  }
 
-  atomicAdd(globalSum,sum);
+    atomicAdd(globalSum, sum);
 }
-
 
 /**
  * free all the values again
@@ -356,19 +403,19 @@ __global__ void allocAll(
  * @param max the maximum number of elements to free
  */
 __global__ void deallocAll(
-    allocElem_t** data,
-    unsigned long long* counter,
+    allocElem_t ** data,
+    unsigned long long * counter,
     const size_t nSlots,
-    ScatterAllocator::AllocatorHandle mMC
-    ){
-
-  while(true){
-    size_t pos = atomicAdd(counter,1);
-    if(pos >= nSlots) break;
-    mMC.free(data[pos]);
-  }
+    ScatterAllocator::AllocatorHandle mMC)
+{
+    while(true)
+    {
+        size_t pos = atomicAdd(counter, 1);
+        if(pos >= nSlots)
+            break;
+        mMC.free(data[pos]);
+    }
 }
-
 
 /**
  * damages one element in the data
@@ -379,10 +426,10 @@ __global__ void deallocAll(
  *
  * @param data the datastructure to damage
  */
-__global__ void damageElement(allocElem_t** data){
-  data[1][0] = static_cast<allocElem_t>(5*ELEMS_PER_SLOT - 1);
+__global__ void damageElement(allocElem_t ** data)
+{
+    data[1][0] = static_cast<allocElem_t>(5 * ELEMS_PER_SLOT - 1);
 }
-
 
 /**
  * wrapper function to allocate memory on device
@@ -399,34 +446,42 @@ __global__ void damageElement(allocElem_t** data){
  * @param threads the number of CUDA threads per block
  */
 void allocate(
-    allocElem_t** d_testData,
-    unsigned long long* h_nSlots,
-    unsigned long long* h_sum,
+    allocElem_t ** d_testData,
+    unsigned long long * h_nSlots,
+    unsigned long long * h_sum,
     const unsigned blocks,
     const unsigned threads,
-    ScatterAllocator* mMC
-    ){
+    ScatterAllocator * mMC)
+{
+    dout() << "allocating on device...";
 
-  dout() << "allocating on device...";
+    unsigned long long zero = 0;
+    unsigned long long * d_sum;
+    unsigned long long * d_nSlots;
 
-  unsigned long long zero = 0;
-  unsigned long long *d_sum;
-  unsigned long long *d_nSlots;
+    MALLOCMC_CUDA_CHECKED_CALL(
+        cudaMalloc((void **)&d_sum, sizeof(unsigned long long)));
+    MALLOCMC_CUDA_CHECKED_CALL(
+        cudaMalloc((void **)&d_nSlots, sizeof(unsigned long long)));
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(
+        d_sum, &zero, sizeof(unsigned long long), cudaMemcpyHostToDevice));
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(
+        d_nSlots, &zero, sizeof(unsigned long long), cudaMemcpyHostToDevice));
 
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc((void**) &d_sum,sizeof(unsigned long long)));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc((void**) &d_nSlots, sizeof(unsigned long long)));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(d_sum,&zero,sizeof(unsigned long long),cudaMemcpyHostToDevice));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(d_nSlots,&zero,sizeof(unsigned long long),cudaMemcpyHostToDevice));
+    CUDA_CHECK_KERNEL_SYNC(
+        allocAll<<<blocks, threads>>>(d_testData, d_nSlots, d_sum, *mMC));
 
-  CUDA_CHECK_KERNEL_SYNC(allocAll<<<blocks,threads>>>(d_testData, d_nSlots, d_sum, *mMC ));
-
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(h_sum,d_sum,sizeof(unsigned long long),cudaMemcpyDeviceToHost));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(h_nSlots,d_nSlots,sizeof(unsigned long long),cudaMemcpyDeviceToHost));
-  cudaFree(d_sum);
-  cudaFree(d_nSlots);
-  dout() << "done\n";
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(
+        h_sum, d_sum, sizeof(unsigned long long), cudaMemcpyDeviceToHost));
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(
+        h_nSlots,
+        d_nSlots,
+        sizeof(unsigned long long),
+        cudaMemcpyDeviceToHost));
+    cudaFree(d_sum);
+    cudaFree(d_nSlots);
+    dout() << "done\n";
 }
-
 
 /**
  * Wrapper function to verify allocation on device
@@ -442,71 +497,73 @@ void allocate(
  * @return true if the verification was successful, false otherwise
  */
 bool verify(
-    allocElem_t **d_testData,
+    allocElem_t ** d_testData,
     const unsigned long long nSlots,
     const unsigned blocks,
-    const unsigned threads
-    ){
+    const unsigned threads)
+{
+    dout() << "verifying on device... ";
 
-  dout() << "verifying on device... ";
+    const unsigned long long zero = 0;
+    int h_correct = 1;
+    int * d_correct;
+    unsigned long long * d_sum;
+    unsigned long long * d_counter;
 
-  const unsigned long long zero = 0;
-  int  h_correct = 1;
-  int* d_correct;
-  unsigned long long *d_sum;
-  unsigned long long *d_counter;
+    MALLOCMC_CUDA_CHECKED_CALL(
+        cudaMalloc((void **)&d_sum, sizeof(unsigned long long)));
+    MALLOCMC_CUDA_CHECKED_CALL(
+        cudaMalloc((void **)&d_counter, sizeof(unsigned long long)));
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc((void **)&d_correct, sizeof(int)));
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(
+        d_sum, &zero, sizeof(unsigned long long), cudaMemcpyHostToDevice));
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(
+        d_counter, &zero, sizeof(unsigned long long), cudaMemcpyHostToDevice));
+    MALLOCMC_CUDA_CHECKED_CALL(
+        cudaMemcpy(d_correct, &h_correct, sizeof(int), cudaMemcpyHostToDevice));
 
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc((void**) &d_sum, sizeof(unsigned long long)));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc((void**) &d_counter, sizeof(unsigned long long)));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc((void**) &d_correct, sizeof(int)));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(d_sum,&zero,sizeof(unsigned long long),cudaMemcpyHostToDevice));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(d_counter,&zero,sizeof(unsigned long long),cudaMemcpyHostToDevice));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(d_correct,&h_correct,sizeof(int),cudaMemcpyHostToDevice));
+    // can be replaced by a call to check_content_fast,
+    // if the gaussian sum (see below) is not used and you
+    // want to be a bit faster
+    CUDA_CHECK_KERNEL_SYNC(check_content<<<blocks, threads>>>(
+        d_testData, d_counter, d_sum, static_cast<size_t>(nSlots), d_correct));
+    MALLOCMC_CUDA_CHECKED_CALL(
+        cudaMemcpy(&h_correct, d_correct, sizeof(int), cudaMemcpyDeviceToHost));
 
-  // can be replaced by a call to check_content_fast,
-  // if the gaussian sum (see below) is not used and you
-  // want to be a bit faster
-  CUDA_CHECK_KERNEL_SYNC(check_content<<<blocks,threads>>>(
-        d_testData,
-        d_counter,
-        d_sum,
-        static_cast<size_t>(nSlots),
-        d_correct
-        ));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(&h_correct,d_correct,sizeof(int),cudaMemcpyDeviceToHost));
+    // This only works, if the type "allocElem_t"
+    // can hold all the IDs (usually unsigned long long)
+    /*
+    dout() << "verifying on host...";
+    unsigned long long h_sum, h_counter;
+    unsigned long long gaussian_sum = (ELEMS_PER_SLOT*nSlots *
+    (ELEMS_PER_SLOT*nSlots-1))/2;
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(&h_sum,d_sum,sizeof(unsigned long
+    long),cudaMemcpyDeviceToHost));
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(&h_counter,d_counter,sizeof(unsigned
+    long long),cudaMemcpyDeviceToHost)); if(gaussian_sum != h_sum){ dout() <<
+    "\nGaussian Sum doesn't match: is " << h_sum; dout() << " (should be " <<
+    gaussian_sum << ")\n"; h_correct=false;
+    }
+    if(nSlots != h_counter-(blocks*threads)){
+      dout() << "\nallocated number of elements doesn't match: is " <<
+    h_counter; dout() << " (should be " << nSlots << ")\n"; h_correct=false;
+    }
+    */
 
-  // This only works, if the type "allocElem_t"
-  // can hold all the IDs (usually unsigned long long)
-  /*
-  dout() << "verifying on host...";
-  unsigned long long h_sum, h_counter;
-  unsigned long long gaussian_sum = (ELEMS_PER_SLOT*nSlots * (ELEMS_PER_SLOT*nSlots-1))/2;
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(&h_sum,d_sum,sizeof(unsigned long long),cudaMemcpyDeviceToHost));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(&h_counter,d_counter,sizeof(unsigned long long),cudaMemcpyDeviceToHost));
-  if(gaussian_sum != h_sum){
-    dout() << "\nGaussian Sum doesn't match: is " << h_sum;
-    dout() << " (should be " << gaussian_sum << ")\n";
-    h_correct=false;
-  }
-  if(nSlots != h_counter-(blocks*threads)){
-    dout() << "\nallocated number of elements doesn't match: is " << h_counter;
-    dout() << " (should be " << nSlots << ")\n";
-    h_correct=false;
-  }
-  */
+    if(h_correct)
+    {
+        dout() << "done\n";
+    }
+    else
+    {
+        dout() << "failed\n";
+    }
 
-  if(h_correct){
-    dout() << "done\n";
-  }else{
-    dout() << "failed\n";
-  }
-
-  cudaFree(d_correct);
-  cudaFree(d_sum);
-  cudaFree(d_counter);
-  return static_cast<bool>(h_correct);
+    cudaFree(d_correct);
+    cudaFree(d_sum);
+    cudaFree(d_counter);
+    return static_cast<bool>(h_correct);
 }
-
 
 /**
  * prints all parameters machine readable
@@ -514,80 +571,78 @@ bool verify(
  * for params, see run_heap_verification-internal parameters
  */
 void print_machine_readable(
-        const unsigned pagesize,
-        const unsigned accessblocks,
-        const unsigned regionsize,
-        const unsigned wastefactor,
-        const bool resetfreedpages,
-        const unsigned blocks,
-        const unsigned threads,
-        const unsigned elemsPerSlot,
-        const size_t allocElemSize,
-        const size_t heapSize,
-        const size_t maxSpace,
-        const size_t maxSlots,
-        const unsigned long long usedSlots,
-        const float allocFrac,
-        const size_t wasted,
-        const bool correct
-        ){
+    const unsigned pagesize,
+    const unsigned accessblocks,
+    const unsigned regionsize,
+    const unsigned wastefactor,
+    const bool resetfreedpages,
+    const unsigned blocks,
+    const unsigned threads,
+    const unsigned elemsPerSlot,
+    const size_t allocElemSize,
+    const size_t heapSize,
+    const size_t maxSpace,
+    const size_t maxSlots,
+    const unsigned long long usedSlots,
+    const float allocFrac,
+    const size_t wasted,
+    const bool correct)
+{
+    std::string sep = ",";
+    std::stringstream h;
+    std::stringstream v;
 
-  std::string sep = ",";
-  std::stringstream h;
-  std::stringstream v;
+    h << "PagesizeByte" << sep;
+    v << pagesize << sep;
 
-  h << "PagesizeByte"   << sep;
-  v << pagesize         << sep;
+    h << "Accessblocks" << sep;
+    v << accessblocks << sep;
 
-  h << "Accessblocks"   << sep;
-  v << accessblocks     << sep;
+    h << "Regionsize" << sep;
+    v << regionsize << sep;
 
-  h << "Regionsize"     << sep;
-  v << regionsize       << sep;
+    h << "Wastefactor" << sep;
+    v << wasted << sep;
 
-  h << "Wastefactor"    << sep;
-  v << wasted           << sep;
+    h << "ResetFreedPage" << sep;
+    v << resetfreedpages << sep;
 
-  h << "ResetFreedPage" << sep;
-  v << resetfreedpages  << sep;
+    h << "Gridsize" << sep;
+    v << blocks << sep;
 
-  h << "Gridsize"       << sep;
-  v <<  blocks          << sep;
+    h << "Blocksize" << sep;
+    v << threads << sep;
 
-  h << "Blocksize"      << sep;
-  v << threads          << sep;
+    h << "ELEMS_PER_SLOT" << sep;
+    v << elemsPerSlot << sep;
 
-  h << "ELEMS_PER_SLOT" << sep;
-  v << elemsPerSlot     << sep;
+    h << "allocElemByte" << sep;
+    v << allocElemSize << sep;
 
-  h << "allocElemByte"  << sep;
-  v << allocElemSize    << sep;
+    h << "heapsizeByte" << sep;
+    v << heapSize << sep;
 
-  h << "heapsizeByte"   << sep;
-  v << heapSize         << sep;
+    h << "maxSpaceByte" << sep;
+    v << maxSpace << sep;
 
-  h << "maxSpaceByte"   << sep;
-  v << maxSpace         << sep;
+    h << "maxSlots" << sep;
+    v << maxSlots << sep;
 
-  h << "maxSlots"       << sep;
-  v << maxSlots         << sep;
+    h << "usedSlots" << sep;
+    v << usedSlots << sep;
 
-  h << "usedSlots"      << sep;
-  v << usedSlots        << sep;
+    h << "allocFraction" << sep;
+    v << allocFrac << sep;
 
-  h << "allocFraction"  << sep;
-  v << allocFrac        << sep;
+    h << "wastedBytes" << sep;
+    v << wasted << sep;
 
-  h << "wastedBytes"    << sep;
-  v << wasted           << sep;
+    h << "correct";
+    v << correct;
 
-  h << "correct"        ;
-  v << correct          ;
-
-  std::cout << h.str() << '\n';
-  std::cout << v.str() << '\n';
+    std::cout << h.str() << '\n';
+    std::cout << v.str() << '\n';
 }
-
 
 /**
  * Verify the heap allocation of mallocMC
@@ -607,98 +662,107 @@ bool run_heap_verification(
     const size_t heapMB,
     const unsigned blocks,
     const unsigned threads,
-    const bool machine_readable
-    ){
+    const bool machine_readable)
+{
+    cudaSetDeviceFlags(cudaDeviceMapHost);
 
-  cudaSetDeviceFlags(cudaDeviceMapHost);
+    const size_t heapSize = size_t(1024U * 1024U) * heapMB;
+    const size_t slotSize = sizeof(allocElem_t) * ELEMS_PER_SLOT;
+    const size_t nPointers = (heapSize + slotSize - 1) / slotSize;
+    const size_t maxSlots = heapSize / slotSize;
+    const size_t maxSpace
+        = maxSlots * slotSize + nPointers * sizeof(allocElem_t *);
+    bool correct = true;
+    const unsigned long long zero = 0;
 
-  const size_t heapSize         = size_t(1024U*1024U) * heapMB;
-  const size_t slotSize         = sizeof(allocElem_t)*ELEMS_PER_SLOT;
-  const size_t nPointers        = (heapSize + slotSize - 1) / slotSize;
-  const size_t maxSlots         = heapSize/slotSize;
-  const size_t maxSpace         = maxSlots*slotSize + nPointers*sizeof(allocElem_t*);
-  bool correct                  = true;
-  const unsigned long long zero = 0;
+    dout() << "CreationPolicy Arguments:\n";
+    dout() << "Pagesize:              " << ScatterConfig::pagesize << '\n';
+    dout() << "Accessblocks:          " << ScatterConfig::accessblocks << '\n';
+    dout() << "Regionsize:            " << ScatterConfig::regionsize << '\n';
+    dout() << "Wastefactor:           " << ScatterConfig::wastefactor << '\n';
+    dout() << "ResetFreedPages        " << ScatterConfig::resetfreedpages
+           << '\n';
+    dout() << "\n";
+    dout() << "Gridsize:              " << blocks << '\n';
+    dout() << "Blocksize:             " << threads << '\n';
+    dout() << "Allocated elements:    " << ELEMS_PER_SLOT << " x "
+           << sizeof(allocElem_t);
+    dout() << "    Byte (" << slotSize << " Byte)\n";
+    dout() << "Heap:                  " << heapSize << " Byte";
+    dout() << " (" << heapSize / pow(1024, 2) << " MByte)\n";
+    dout() << "max space w/ pointers: " << maxSpace << " Byte";
+    dout() << " (" << maxSpace / pow(1024, 2) << " MByte)\n";
+    dout() << "maximum of elements:   " << maxSlots << '\n';
 
-  dout() << "CreationPolicy Arguments:\n";
-  dout() << "Pagesize:              "     << ScatterConfig::pagesize        << '\n';
-  dout() << "Accessblocks:          "     << ScatterConfig::accessblocks    << '\n';
-  dout() << "Regionsize:            "     << ScatterConfig::regionsize      << '\n';
-  dout() << "Wastefactor:           "     << ScatterConfig::wastefactor     << '\n';
-  dout() << "ResetFreedPages        "     << ScatterConfig::resetfreedpages << '\n';
-  dout() << "\n";
-  dout() << "Gridsize:              "     << blocks                             << '\n';
-  dout() << "Blocksize:             "     << threads                            << '\n';
-  dout() << "Allocated elements:    "     << ELEMS_PER_SLOT << " x "  << sizeof(allocElem_t);
-  dout() << "    Byte ("  << slotSize     << " Byte)\n";
-  dout() << "Heap:                  "     << heapSize << " Byte";
-  dout() << " (" << heapSize/pow(1024,2)  << " MByte)\n";
-  dout() << "max space w/ pointers: "     << maxSpace << " Byte";
-  dout() << " (" << maxSpace/pow(1024,2)  << " MByte)\n";
-  dout() << "maximum of elements:   "     << maxSlots                           << '\n';
+    // initializing the heap
+    ScatterAllocator * mMC = new ScatterAllocator(heapSize);
+    allocElem_t ** d_testData;
+    MALLOCMC_CUDA_CHECKED_CALL(
+        cudaMalloc((void **)&d_testData, nPointers * sizeof(allocElem_t *)));
 
-  // initializing the heap
-  ScatterAllocator* mMC = new ScatterAllocator(heapSize);
-  allocElem_t** d_testData;
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc((void**) &d_testData, nPointers*sizeof(allocElem_t*)));
+    // allocating with mallocMC
+    unsigned long long usedSlots = 0;
+    unsigned long long sumAllocElems = 0;
+    allocate(d_testData, &usedSlots, &sumAllocElems, blocks, threads, mMC);
 
-  // allocating with mallocMC
-  unsigned long long usedSlots = 0;
-  unsigned long long sumAllocElems = 0;
-  allocate(d_testData, &usedSlots, &sumAllocElems, blocks, threads, mMC);
+    const float allocFrac = static_cast<float>(usedSlots) * 100 / maxSlots;
+    const size_t wasted = heapSize - static_cast<size_t>(usedSlots) * slotSize;
+    dout() << "allocated elements:    " << usedSlots;
+    dout() << " (" << allocFrac << "%)\n";
+    dout() << "wasted heap space:     " << wasted << " Byte";
+    dout() << " (" << wasted / pow(1024, 2) << " MByte)\n";
 
-  const float allocFrac = static_cast<float>(usedSlots)*100/maxSlots;
-  const size_t wasted = heapSize - static_cast<size_t>(usedSlots) * slotSize;
-  dout() << "allocated elements:    "   << usedSlots;
-  dout() << " (" << allocFrac << "%)\n";
-  dout() << "wasted heap space:     "   << wasted << " Byte";
-  dout() << " (" << wasted/pow(1024,2)  << " MByte)\n";
+    // verifying on device
+    correct = correct && verify(d_testData, usedSlots, blocks, threads);
 
-  // verifying on device
-  correct = correct && verify(d_testData,usedSlots,blocks,threads);
+    // damaging one cell
+    dout() << "damaging of element... ";
+    CUDA_CHECK_KERNEL_SYNC(damageElement<<<1, 1>>>(d_testData));
+    dout() << "done\n";
 
-  // damaging one cell
-  dout() << "damaging of element... ";
-  CUDA_CHECK_KERNEL_SYNC(damageElement<<<1,1>>>(d_testData));
-  dout() << "done\n";
+    // verifying on device
+    // THIS SHOULD FAIL (damage was done before!). Therefore, we must inverse
+    // the logic
+    correct = correct && !verify(d_testData, usedSlots, blocks, threads);
 
-  // verifying on device
-  // THIS SHOULD FAIL (damage was done before!). Therefore, we must inverse the logic
-  correct = correct && !verify(d_testData,usedSlots,blocks,threads);
+    // release all memory
+    dout() << "deallocation...        ";
+    unsigned long long * d_dealloc_counter;
+    MALLOCMC_CUDA_CHECKED_CALL(
+        cudaMalloc((void **)&d_dealloc_counter, sizeof(unsigned long long)));
+    MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(
+        d_dealloc_counter,
+        &zero,
+        sizeof(unsigned long long),
+        cudaMemcpyHostToDevice));
+    CUDA_CHECK_KERNEL_SYNC(deallocAll<<<blocks, threads>>>(
+        d_testData, d_dealloc_counter, static_cast<size_t>(usedSlots), *mMC));
+    cudaFree(d_dealloc_counter);
+    cudaFree(d_testData);
+    delete mMC;
 
+    dout() << "done \n";
 
-  // release all memory
-  dout() << "deallocation...        ";
-  unsigned long long* d_dealloc_counter;
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc((void**) &d_dealloc_counter, sizeof(unsigned long long)));
-  MALLOCMC_CUDA_CHECKED_CALL(cudaMemcpy(d_dealloc_counter,&zero,sizeof(unsigned long long),cudaMemcpyHostToDevice));
-  CUDA_CHECK_KERNEL_SYNC(deallocAll<<<blocks,threads>>>(d_testData,d_dealloc_counter,static_cast<size_t>(usedSlots), *mMC ));
-  cudaFree(d_dealloc_counter);
-  cudaFree(d_testData);
-  delete mMC;
+    if(machine_readable)
+    {
+        print_machine_readable(
+            ScatterConfig::pagesize,
+            ScatterConfig::accessblocks,
+            ScatterConfig::regionsize,
+            ScatterConfig::wastefactor,
+            ScatterConfig::resetfreedpages,
+            blocks,
+            threads,
+            ELEMS_PER_SLOT,
+            sizeof(allocElem_t),
+            heapSize,
+            maxSpace,
+            maxSlots,
+            usedSlots,
+            allocFrac,
+            wasted,
+            correct);
+    }
 
-  dout() << "done \n";
-
-  if(machine_readable){
-    print_machine_readable(
-        ScatterConfig::pagesize,
-        ScatterConfig::accessblocks,
-        ScatterConfig::regionsize,
-        ScatterConfig::wastefactor,
-        ScatterConfig::resetfreedpages,
-        blocks,
-        threads,
-        ELEMS_PER_SLOT,
-        sizeof(allocElem_t),
-        heapSize,
-        maxSpace,
-        maxSlots,
-        usedSlots,
-        allocFrac,
-        wasted,
-        correct
-        );
-  }
-
-  return correct;
+    return correct;
 }

--- a/tests/verify_heap.cu
+++ b/tests/verify_heap.cu
@@ -64,11 +64,11 @@ bool verbose = false;
 // the type of the elements to allocate
 using allocElem_t = unsigned long long;
 
-bool run_heap_verification(
+auto run_heap_verification(
     const size_t,
     const unsigned,
     const unsigned,
-    const bool);
+    const bool) -> bool;
 void parse_cmdline(
     const int,
     char **,
@@ -85,7 +85,7 @@ struct nullstream : std::ostream
 };
 
 // uses global verbosity to switch between std::cout and a nullptr-output
-std::ostream & dout()
+auto dout() -> std::ostream &
 {
     static nullstream n;
     return verbose ? std::cout : n;
@@ -105,7 +105,7 @@ static constexpr size_t heapInMB_default = 1024; // 1GB
  * @return will return 0 if the verification was successful,
  *         otherwise returns 1
  */
-int main(int argc, char ** argv)
+auto main(int argc, char ** argv) -> int
 {
     bool correct = false;
     bool machine_readable = false;
@@ -496,11 +496,11 @@ void allocate(
  * @param threads the number of CUDA threads per block
  * @return true if the verification was successful, false otherwise
  */
-bool verify(
+auto verify(
     allocElem_t ** d_testData,
     const unsigned long long nSlots,
     const unsigned blocks,
-    const unsigned threads)
+    const unsigned threads) -> bool
 {
     dout() << "verifying on device... ";
 
@@ -658,11 +658,11 @@ void print_machine_readable(
  * @return true if the verification was successful,
  *         false otherwise
  */
-bool run_heap_verification(
+auto run_heap_verification(
     const size_t heapMB,
     const unsigned blocks,
     const unsigned threads,
-    const bool machine_readable)
+    const bool machine_readable) -> bool
 {
     cudaSetDeviceFlags(cudaDeviceMapHost);
 

--- a/tests/verify_heap_config.hpp
+++ b/tests/verify_heap_config.hpp
@@ -32,44 +32,47 @@
 #include <mallocMC/mallocMC_hostclass.hpp>
 
 // Load all available policies for mallocMC
+#include <mallocMC/AlignmentPolicies.hpp>
 #include <mallocMC/CreationPolicies.hpp>
 #include <mallocMC/DistributionPolicies.hpp>
 #include <mallocMC/OOMPolicies.hpp>
 #include <mallocMC/ReservePoolPolicies.hpp>
-#include <mallocMC/AlignmentPolicies.hpp>
 
 // configurate the CreationPolicy "Scatter"
-struct ScatterConfig{
-  static constexpr auto pagesize = 4096;
-  static constexpr auto accessblocks = 8;
-  static constexpr auto regionsize = 16;
-  static constexpr auto wastefactor = 2;
-  static constexpr auto resetfreedpages = false;
+struct ScatterConfig
+{
+    static constexpr auto pagesize = 4096;
+    static constexpr auto accessblocks = 8;
+    static constexpr auto regionsize = 16;
+    static constexpr auto wastefactor = 2;
+    static constexpr auto resetfreedpages = false;
 };
 
-struct ScatterHashParams{
-  static constexpr auto hashingK = 38183;
-  static constexpr auto hashingDistMP = 17497;
-  static constexpr auto hashingDistWP = 1;
-  static constexpr auto hashingDistWPRel = 1;
+struct ScatterHashParams
+{
+    static constexpr auto hashingK = 38183;
+    static constexpr auto hashingDistMP = 17497;
+    static constexpr auto hashingDistWP = 1;
+    static constexpr auto hashingDistWPRel = 1;
 };
 
 // configure the DistributionPolicy "XMallocSIMD"
-struct DistributionConfig{
-  static constexpr auto pagesize = ScatterConfig::pagesize;
+struct DistributionConfig
+{
+    static constexpr auto pagesize = ScatterConfig::pagesize;
 };
 
 // configure the AlignmentPolicy "Shrink"
-struct AlignmentConfig{
-  static constexpr auto dataAlignment = 16;
+struct AlignmentConfig
+{
+    static constexpr auto dataAlignment = 16;
 };
 
 // Define a new allocator and call it ScatterAllocator
 // which resembles the behaviour of ScatterAlloc
 using ScatterAllocator = mallocMC::Allocator<
-  mallocMC::CreationPolicies::Scatter<ScatterConfig,ScatterHashParams>,
-  mallocMC::DistributionPolicies::XMallocSIMD<DistributionConfig>,
-  mallocMC::OOMPolicies::ReturnNull,
-  mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
-  mallocMC::AlignmentPolicies::Shrink<AlignmentConfig>
->;
+    mallocMC::CreationPolicies::Scatter<ScatterConfig, ScatterHashParams>,
+    mallocMC::DistributionPolicies::XMallocSIMD<DistributionConfig>,
+    mallocMC::OOMPolicies::ReturnNull,
+    mallocMC::ReservePoolPolicies::SimpleCudaMalloc,
+    mallocMC::AlignmentPolicies::Shrink<AlignmentConfig>>;


### PR DESCRIPTION
* added a .clang-format file, based on the one suggested for alpaka: https://github.com/alpaka-group/alpaka/pull/781
* formatted whole codebase
* enabled trailing return types in clang-tidy and applied fix