### PR TITLE
fix HIP support

### DIFF
--- a/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
+++ b/src/include/mallocMC/creationPolicies/Scatter_impl.hpp
@@ -619,8 +619,8 @@ namespace mallocMC
                             _page[page].init();
                             // remove chunk information
                             _ptes[page].chunksize = 0;
-#if defined(__CUDA_ARCH__) \
-    || (defined(__HIP_DEVICE_COMPILE__) && defined(__HIP__))
+
+#if(MALLOCMC_DEVICE_COMPILE)
                             __threadfence(); // TODO alpaka
 #else
                             std::atomic_thread_fence(
@@ -782,10 +782,12 @@ namespace mallocMC
 
                 // only one thread per warp can acquire the mutex
                 void * res = 0;
-                const uint32_t mask = activemask();
-                const uint64_t num = popc(mask);
-                const uint64_t lanemask = lanemask_lt();
-                const auto local_id = popc(lanemask & mask);
+                // based on the alpaka backend the lanemask type can be 64bit
+                const auto mask = activemask();
+                const uint32_t num = popc(mask);
+                // based on the alpaka backend the lanemask type can be 64bit
+                const auto lanemask = lanemask_lt();
+                const uint32_t local_id = popc(lanemask & mask);
                 for(unsigned int active = 0; active < num; ++active)
                     if(active == local_id)
                         res = allocPageBasedSingle(acc, bytes);
@@ -807,8 +809,8 @@ namespace mallocMC
             {
                 const uint32 pages = divup(bytes, pagesize);
                 for(uint32 p = page; p < page + pages; ++p) _page[p].init();
-#if defined(__CUDA_ARCH__) \
-    || (defined(__HIP_DEVICE_COMPILE__) && defined(__HIP__))
+
+#if(MALLOCMC_DEVICE_COMPILE)
                 __threadfence(); // TODO alpaka
 #else
                 std::atomic_thread_fence(
@@ -829,7 +831,12 @@ namespace mallocMC
              * @return pointer to the allocated memory
              */
             template<typename AlpakaAcc>
-            ALPAKA_FN_ACC auto create(const AlpakaAcc & acc, uint32 bytes)
+            ALPAKA_FN_ACC
+#if(BOOST_COMP_CLANG && BOOST_LANG_HIP)
+            // The clang HIP compiler is producing runtime errors if this method is inlined.
+            __noinline__
+#endif
+            auto create(const AlpakaAcc & acc, uint32 bytes)
                 -> void *
             {
                 if(bytes == 0)
@@ -1019,10 +1026,15 @@ namespace mallocMC
                     typename alpaka::dim::traits::DimType<AlpakaAcc>::type;
                 using Idx =
                     typename alpaka::idx::traits::IdxType<AlpakaAcc>::type;
+                using VecType = alpaka::vec::Vec<Dim, Idx>;
+
+                auto threadsPerBlock = VecType::ones();
+                threadsPerBlock[Dim::value - 1] = 256u;
+
                 const auto workDiv = alpaka::workdiv::WorkDivMembers<Dim, Idx>{
-                    Idx{1},
-                    Idx{256},
-                    Idx{1}}; // Dim may be any dimension, but workDiv is 1D
+                    VecType::ones(),
+                    threadsPerBlock,
+                    VecType::ones()}; // Dim may be any dimension, but workDiv is 1D
                 alpaka::queue::enqueue(
                     queue,
                     alpaka::kernel::createTaskKernel<AlpakaAcc>(
@@ -1218,10 +1230,18 @@ namespace mallocMC
                     typename alpaka::dim::traits::DimType<AlpakaAcc>::type;
                 using Idx =
                     typename alpaka::idx::traits::IdxType<AlpakaAcc>::type;
+
+                using VecType = alpaka::vec::Vec<Dim, Idx>;
+
+                auto numBlocks = VecType::ones();
+                numBlocks[Dim::value - 1] = 64u;
+                auto threadsPerBlock = VecType::ones();
+                threadsPerBlock[Dim::value - 1] = 256u;
+
                 const auto workDiv = alpaka::workdiv::WorkDivMembers<Dim, Idx>{
-                    Idx{64},
-                    Idx{256},
-                    Idx{1}}; // Dim may be any dimension, but workDiv is 1D
+                    numBlocks,
+                    threadsPerBlock,
+                    VecType::ones()}; // Dim may be any dimension, but workDiv is 1D
 
                 alpaka::queue::enqueue(
                     queue,
@@ -1293,8 +1313,8 @@ namespace mallocMC
                 if(temp)
                     alpaka::atomic::atomicOp<alpaka::atomic::op::Add>(
                         acc, &warpResults[wId], temp);
-#if defined(__CUDA_ARCH__) \
-    || (defined(__HIP_DEVICE_COMPILE__) && defined(__HIP__))
+
+#if(MALLOCMC_DEVICE_COMPILE)
                 __threadfence_block();
 #else
                 std::atomic_thread_fence(

--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -104,9 +104,9 @@ namespace mallocMC
                 // second half: make sure that all coalesced allocations can fit
                 // within one page necessary for offset calculation
                 const bool coalescible = bytes > 0 && bytes < (pagesize / 32);
-#if defined(__CUDA_ARCH__) \
-    || (defined(__HIP_DEVICE_COMPILE__) && defined(__HIP__))
-                threadcount = popc(__ballot_sync(__activemask(), coalescible));
+
+#if(MALLOCMC_DEVICE_COMPILE)
+                threadcount = popc(ballot(coalescible));
 #else
                 threadcount = 1; // TODO
 #endif
@@ -140,8 +140,8 @@ namespace mallocMC
                     if(myalloc != 0)
                         *(uint32 *)myalloc = threadcount;
                 }
-#if defined(__CUDA_ARCH__) \
-    || (defined(__HIP_DEVICE_COMPILE__) && defined(__HIP__))
+
+#if(MALLOCMC_DEVICE_COMPILE)
                 __threadfence_block();
 #else
                 std::atomic_thread_fence(

--- a/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
+++ b/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
@@ -42,7 +42,7 @@ namespace mallocMC
             ALPAKA_FN_ACC
             static auto handleOOM(void * mem) -> void *
             {
-#ifdef __CUDACC__
+#if BOOST_LANG_CUDA || BOOST_COMP_HIP
 //#if __CUDA_ARCH__ < 350
 #define PM_EXCEPTIONS_NOT_SUPPORTED_HERE
 //#endif


### PR DESCRIPTION
- set warpsize for HIP AMD devices to 64
- fix wrong type for `activemask` - is 64bit if HIP is used
- handle compile issue with HIP-clang
