### PR TITLE
fix clang cuda compile

### DIFF
--- a/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
+++ b/src/include/mallocMC/distributionPolicies/XMallocSIMD.hpp
@@ -168,12 +168,8 @@ namespace mallocMC
                         *(uint32 *)myalloc = threadcount;
                 }
 
-#if(MALLOCMC_DEVICE_COMPILE)
-                __threadfence_block();
-#else
-                std::atomic_thread_fence(
-                    std::memory_order::memory_order_seq_cst);
-#endif
+                threadfenceBlock(acc);
+
                 void * myres = myalloc;
                 if(can_use_coalescing)
                 {


### PR DESCRIPTION
Clang with native CUDA compile was running into compile isssues.

```
mallocMC/creationPolicies/Scatter.hpp:1355:22: error: reference to __host__ function 'atomic_thread_fence' in __device__ function
                std::atomic_thread_fence(
                     ^
```

Provide a trait based on alpaka concepts to provide threadfence functionallity.