### PR TITLE
Update documentation after switch to alpaka

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,29 +4,20 @@ Install
  - `gcc` 4.4 - 4.8 (depends on current CUDA version)
   - *Debian/Ubuntu:* `sudo apt-get install gcc-4.4 build-essential`
   - *Arch Linux:* `sudo pacman -S base-devel`
- - [CUDA 5.0](https://developer.nvidia.com/cuda-downloads) or higher
-  - *Debian/Ubuntu:* `sudo apt-get install nvidia-common nvidia-current nvidia-cuda-toolkit nvidia-cuda-dev`
-  - *Arch Linux:* `sudo pacman -S cuda`
- - one Nvidia **CUDA** compatible **GPU** with compute capability >= 2.0
-  - [full list](https://developer.nvidia.com/cuda-gpus) of CUDA GPUs and their *compute capability*
- - `boost` >= 1.48
-   - compile time headers
-   - `boost::program_options`
+ - `alpaka`
+  - included as git submodule
+ - `boost` >= 1.65.1
+   - dependency of alpaka
    - *Debian/Ubuntu:* `sudo apt-get install libboost-dev libboost-program-options-dev`
    - *Arch Linux:* `sudo pacman -S boost`
    - or download from [http://www.boost.org/](http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz/download)
- - `CMake` >= 2.8.12.2
+ - `CMake` >= 3.15
   - *Debian/Ubuntu:* `sudo apt-get install cmake file cmake-curses-gui`
   - *Arch Linux:* `sudo pacman -S cmake`
  - `git` >= 1.7.9.5
   - *Debian/Ubuntu:* `sudo apt-get install git`
   - *Arch Linux:* `sudo pacman -S git`
 
-
-### Mandatory environment variables
- - `CUDA_ROOT`: CUDA installation directory, e.g. `export CUDA_ROOT=<CUDA_INSTALL>`
-  - this might be already set through your CUDA toolkit
- - `BOOST_ROOT`: Boost installation directory, e.g. `export BOOST_ROOT=<BOOST_INSTALL>`
 
 ### Examples
 This is an example how to compile `mallocMC` and test the example code snippets
@@ -54,7 +45,7 @@ To use mallocMC in your project, you must include the header `mallocMC/mallocMC.
 add the correct include path.
 
 Because we are linking to Boost and CUDA, the following **external dependencies** must be linked:
-- `-lboost`, `-lcudart`
+- `-lboost`
 
 If you are using CMake you can download our `FindmallocMC.cmake` module with
 ```bash
@@ -71,21 +62,10 @@ cmake_minimum_required(VERSION 2.8.12.2)
 # add path to FindmallocMC.cmake, e.g., in the directory in cmake/
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)
 
-# find the packages that are required by mallocMC. This has to be done BEFORE
-# loading mallocMC
-find_package(Boost REQUIRED)
-set(LIBS ${LIBS} ${Boost_LIBRARIES})
-
-find_package(CUDA REQUIRED)
-cuda_include_directories(${CUDA_INCLUDE_DIRS})
-
 # find mallocMC installation
 find_package(mallocMC 2.0.1 REQUIRED)
 
-# where to find headers (-I includes for compiler)
-include_directories(SYSTEM ${mallocMC_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
-
-add_executable(yourBinary ${SOURCES})
-
-target_link_libraries(yourBinary ${LIBS})
+alpaka_add_executable(yourBinary ${SOURCES})
+target_include_directories(yourBinary PUBLIC ${mallocMC_INCLUDE_DIRS})
+target_link_libraries(yourBinary PUBLIC alpaka::alpaka)
 ```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ mallocMC
 mallocMC: *Memory Allocator for Many Core Architectures*
 
 This project provides a framework for **fast memory managers** on **many core
-accelerators**. Currently, it supports **NVIDIA GPUs** of compute capability
-`sm_20` or higher through the *ScatterAlloc* algorithm.
+accelerators**. It is based on [alpaka](https://github.com/alpaka-group/alpaka)
+to run on many different accelerators and implements the *ScatterAlloc* algorithm.
 
 
 Usage


### PR DESCRIPTION
Here is a quick fix of the documentation after we exchanged CUDA for alpaka.